### PR TITLE
Improve appearance on Windows 10 dark mode

### DIFF
--- a/app/VLC.Universal/Resources/Colors.xaml
+++ b/app/VLC.Universal/Resources/Colors.xaml
@@ -25,7 +25,6 @@
             <Color x:Key="TransparentApplicationThirdForegroundThemeColor">#00252525</Color>
             <Color x:Key="ApplicationOverlayTranslucentThemeColor">#e5151515</Color>
 
-
             <SolidColorBrush x:Key="ApplicationChromeThemeBrush"
                              Color="#AA202020"/>
             <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush"
@@ -89,7 +88,7 @@
             <Color x:Key="ApplicationFourthForegroundThemeColor">#e0e0e0</Color>
             <Color x:Key="TransparentApplicationThirdForegroundThemeColor">#00f5f5f5</Color>
             <Color x:Key="ApplicationOverlayTranslucentThemeColor">#DEFEFEFE</Color>
-
+            
             <SolidColorBrush x:Key="ApplicationChromeThemeBrush"
                              Color="#AAF2F2F2" />
             <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush"

--- a/app/VLC.Universal/Resources/Colors.xaml
+++ b/app/VLC.Universal/Resources/Colors.xaml
@@ -28,18 +28,18 @@
             <SolidColorBrush x:Key="ApplicationChromeThemeBrush"
                              Color="#AA202020"/>
             <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush"
-                             Color="{StaticResource ApplicationPageBackgroundThemeColor}" />
+                             Color="{ThemeResource ApplicationPageBackgroundThemeColor}" />
             <SolidColorBrush x:Key="PivotHeaderForegroundUnselectedBrush"
                              Color="#B2FFFFFF" />
             <SolidColorBrush x:Key="ApplicationSecondaryForegroundThemeBrush"
                              Color="LightGray" />
             <SolidColorBrush x:Key="ApplicationThirdForegroundThemeBrush"
-                             Color="{StaticResource ApplicationThirdForegroundThemeColor}" />
+                             Color="{ThemeResource ApplicationThirdForegroundThemeColor}" />
             <SolidColorBrush x:Key="ApplicationFourthForegroundThemeBrush"
-                             Color="{StaticResource ApplicationFourthForegroundThemeColor}" />
+                             Color="{ThemeResource ApplicationFourthForegroundThemeColor}" />
             
             <SolidColorBrush x:Key="ApplicationOverlayTranslucentThemeBrush"
-                             Color="{StaticResource ApplicationOverlayTranslucentThemeColor}" />
+                             Color="{ThemeResource ApplicationOverlayTranslucentThemeColor}" />
             <SolidColorBrush x:Key="ApplicationBackgroundSemiTranslucentThemeBrush"
                              Color="#AF202020" />
             <SolidColorBrush x:Key="ApplicationBackgroundQuarterTranslucentThemeBrush"
@@ -92,18 +92,18 @@
             <SolidColorBrush x:Key="ApplicationChromeThemeBrush"
                              Color="#AAF2F2F2" />
             <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush"
-                             Color="{StaticResource ApplicationPageBackgroundThemeColor}" />
+                             Color="{ThemeResource ApplicationPageBackgroundThemeColor}" />
             <SolidColorBrush x:Key="PivotHeaderForegroundUnselectedBrush"
                              Color="DimGray" />
             <SolidColorBrush x:Key="ApplicationSecondaryForegroundThemeBrush"
                              Color="DimGray" />
             <SolidColorBrush x:Key="ApplicationThirdForegroundThemeBrush"
-                             Color="{StaticResource ApplicationThirdForegroundThemeColor}" />
+                             Color="{ThemeResource ApplicationThirdForegroundThemeColor}" />
             <SolidColorBrush x:Key="ApplicationFourthForegroundThemeBrush"
-                             Color="{StaticResource ApplicationFourthForegroundThemeColor}" />
+                             Color="{ThemeResource ApplicationFourthForegroundThemeColor}" />
             
             <SolidColorBrush x:Key="ApplicationOverlayTranslucentThemeBrush"
-                             Color="{StaticResource ApplicationOverlayTranslucentThemeColor}" />
+                             Color="{ThemeResource ApplicationOverlayTranslucentThemeColor}" />
             <SolidColorBrush x:Key="ApplicationBackgroundSemiTranslucentThemeBrush"
                              Color="#AFEAEAEA" />
             <SolidColorBrush x:Key="ApplicationBackgroundQuarterTranslucentThemeBrush"

--- a/app/VLC.Universal/Resources/Styles.xaml
+++ b/app/VLC.Universal/Resources/Styles.xaml
@@ -87,11 +87,11 @@
     <Style x:Key="BasicTextStyle"
            TargetType="TextBlock">
         <Setter Property="Foreground"
-                Value="{StaticResource ApplicationForegroundThemeBrush}" />
+                Value="{ThemeResource ApplicationForegroundThemeBrush}" />
         <Setter Property="FontSize"
-                Value="{StaticResource ControlContentThemeFontSize}" />
+                Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="FontFamily"
-                Value="{StaticResource ContentControlThemeFontFamily}" />
+                Value="{ThemeResource ContentControlThemeFontFamily}" />
         <Setter Property="TextTrimming"
                 Value="WordEllipsis" />
         <Setter Property="TextWrapping"
@@ -384,7 +384,7 @@
         <Setter Property="Background"
                 Value="Transparent" />
         <Setter Property="BorderBrush"
-                Value="{StaticResource ProgressBarBorderThemeBrush}" />
+                Value="{ThemeResource ProgressBarBorderThemeBrush}" />
         <Setter Property="Maximum"
                 Value="100" />
         <Setter Property="MinHeight"

--- a/app/VLC.Universal/Views/SettingsPages/SettingsPage.xaml
+++ b/app/VLC.Universal/Views/SettingsPages/SettingsPage.xaml
@@ -16,7 +16,7 @@
                       FontFamily="{StaticResource VLCFont}"
                       FontSize="19"
                       Margin="{StaticResource FrameMarginLeft}"
-                      Foreground="{StaticResource MainColor}" />
+                      Foreground="{ThemeResource MainColor}" />
         </Pivot.LeftHeader>
         <PivotItem Header="{Binding Source={StaticResource Strings}, Path=UserInterface}">
                 <ScrollViewer Style="{StaticResource VerticalScrollViewerStyle}">

--- a/app/VLC.Universal/Views/UserControls/PivotHeaderControl.xaml
+++ b/app/VLC.Universal/Views/UserControls/PivotHeaderControl.xaml
@@ -36,10 +36,10 @@
                   FontSize="21"
                   VerticalAlignment="Center"
                   Margin="0,0,6,0"
-                  Foreground="{ThemeResource ApplicationPageBackgroundThemeColor}" />
+                  Foreground="{ThemeResource ApplicationForegroundThemeBrush}" />
         <TextBlock x:Name="Title"
                    VerticalAlignment="Center"
                    FontWeight="Light"
-                   Foreground="{ThemeResource ApplicationPageBackgroundThemeColor}"/>
+                   Foreground="{ThemeResource ApplicationForegroundThemeBrush}"/>
     </StackPanel>
 </UserControl>

--- a/app/VLC.Universal/Views/VariousPages/AboutPage.xaml
+++ b/app/VLC.Universal/Views/VariousPages/AboutPage.xaml
@@ -41,7 +41,8 @@
                             <Run Text="The sources to this application can be retrieved at http://code.videolan.org/videolan/vlc-winrt" />
                             <LineBreak />
                             <Run Text="If you want to manually deploy the package by yourself, without having to pay for a Dev License, follow the steps in this link:" />
-                            <Hyperlink NavigateUri="https://msdn.microsoft.com/en-us/library/windows/apps/dn614128.aspx">Msdn library</Hyperlink>
+                            <Hyperlink Foreground="DarkOrange" 
+                                       NavigateUri="https://msdn.microsoft.com/en-us/library/windows/apps/dn614128.aspx">Msdn library</Hyperlink>
                             <LineBreak />
                             <LineBreak />
                             <Run Text="Libraries"

--- a/app/VLC.Universal/Views/VariousPages/AboutPage.xaml
+++ b/app/VLC.Universal/Views/VariousPages/AboutPage.xaml
@@ -14,7 +14,7 @@
                       FontFamily="{StaticResource VLCFont}"
                       FontSize="19"
                       Margin="{StaticResource FrameMarginLeft}"
-                      Foreground="{StaticResource MainColor}" />
+                      Foreground="{ThemeResource MainColor}" />
         </Pivot.LeftHeader>
         <PivotItem Header="VLC for Windows (Universal)">
             <Grid>
@@ -41,7 +41,7 @@
                             <Run Text="The sources to this application can be retrieved at http://code.videolan.org/videolan/vlc-winrt" />
                             <LineBreak />
                             <Run Text="If you want to manually deploy the package by yourself, without having to pay for a Dev License, follow the steps in this link:" />
-                            <Hyperlink Foreground="AccentColor" 
+                            <Hyperlink Foreground="{ThemeResource MainColor}" 
                                        NavigateUri="https://msdn.microsoft.com/en-us/library/windows/apps/dn614128.aspx">Msdn library</Hyperlink>
                             <LineBreak />
                             <LineBreak />
@@ -51,133 +51,133 @@
                             <Run Text="Some VLC plugins use external libraries that make extensive use of the following persons' or companies' code:" />
                             <LineBreak />
                             <Run Text="FFmpeg/Libav - Copyright ; 2000-2010 the FFmpeg developers -" /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="FLAC - Copyright (c) 2001-2012 Josh Coalson et al. - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <Run Text=", codec libs" /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="#xiph">Xiph.org BSD license</Hyperlink>
                             <LineBreak />
                             <Run Text="Freetype2 - Copyright (c) 2006-2011 by David Turner, Robert Wilhelm, and Werner Lemberg. - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="Fribidi - Copyright (c) Behdad Esfahbod - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="GnuTLS - Copyright (c) 2000-2012 Free Software Foundation - " />
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-3.0.txt">GPL v3 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="GOOM! - Copyright (c) 2000-2004 Jean-Christophe Hoelt - " />
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="GSM - Copyright (c) 1992-1994 Jutta Degener &amp; Carsten Bormann - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="#gsm">GSM permissive license</Hyperlink>
                             <LineBreak />
                             <Run Text="liba52 - Copyright (c) Aaron Holtzman, Michel Lespinasse, et al. - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libass - Copyright (c) Evgeniy Stepanov, Grigori Goronzy, et al. - " />
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://opensource.org/licenses/ISC">ISC license</Hyperlink>
                             <LineBreak />
                             <Run Text="libdca - Copyright (c) Gildas Bazin, Sam Hocevar, et al. - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libdvbpsi - Copyright (c) 2001-2010 VideoLAN - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libebml - Copyright (c) 2002-2010 Steve Lhomme - " />
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libgcrypt - Copyright (c) 2000-2012 Free Software Foundation. - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libgpg-error - Copyright (c) 2003 g10 Code GmbH - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libiconv - Copyright (c) 1999-2001 Free Software Foundation - " />
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libmad - Copyright (c) 2000-2004 Underbit Technologies, Inc. - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libmatroska - Copyright (c) 2002-2003 Steve Lhomme - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libmodplug - Olivier Lapicque, Konstanty - " />
                             <Italic>Public domain</Italic>
                             <LineBreak />
                             <Run Text="libmpeg2 - Copyright (c) 1999-2012 Sam Hocevar, Aaron Holtzman, Michel Lespinasse, Christophe Massiot, et al. - " />
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libogg - Copyright (c) 2002 Xiph.org Foundation - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="#xiph">Xiph.org BSD license</Hyperlink>
                             <LineBreak />
                             <Run Text="libpng - Copyright (c) 2004,2006-2012 Glenn Randers-Pehrson, et al. - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.libpng.org/pub/png/src/libpng-LICENSE.txt">libpng license</Hyperlink>
                             <LineBreak />
                             <Run Text="libpostproc - Copyright (c) 2001-2003 Michael Niedermayer - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libtheora - Copyright (c) Xiph.org - " />
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="#xiph">Xiph.org BSD license</Hyperlink>
                             <LineBreak />
                             <Run Text="libxml2 - Copyright (c) 1998-2003 Daniel Veillard - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.opensource.org/licenses/mit-license.php">MIT license</Hyperlink>
                             <LineBreak />
                             <Run Text="live555 - Copyright (c) 1996-2012 Live Networks, Inc - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="Lua - Copyright (c) 1994-2008 Lua.org - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.opensource.org/licenses/mit-license.php">MIT license</Hyperlink>
                             <LineBreak />
                             <Run Text="Openjpeg - Copyright (c) 2002-2012, Communications and Remote Sensing Laboratory, UCL, Belgium - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://opensource.org/licenses/ISC">ISC license</Hyperlink>
                             <LineBreak />
                             <Run Text="ORC - Copyright (c) 2002-2009 David A. Schleef - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://opensource.org/licenses/ISC">ISC license</Hyperlink>
                             <LineBreak />
                             <Run Text="Schroedinger - Copyright (c) David Schleef, W.J. van der Laan - " />
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.opensource.org/licenses/mit-license.php">MIT license</Hyperlink>
                             <LineBreak />
                             <Run Text="Speex, Speexdsp - Copyright (c) 1992-2008 Xiph.org Foundation, Jean-Marc Valin, Analog Devices Inc, Commonwealth Scientific and Industrial Research Organisation, David Rowe, Jutta Degener, Carsten Bormann - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.opensource.org/licenses/BSD-3-Clause">3-clause BSD license</Hyperlink>
                             <LineBreak />
                             <Run Text="Taglib - Copyright (c) 2002-2008 Scott Wheeler, et al. - " />
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="Zlib - Copyright (c) 1995-2012 Jean-loup Gailly and Mark Adler - " /> 
-                            <Hyperlink Foreground="AccentColor"
+                            <Hyperlink Foreground="{ThemeResource MainColor}"
                                        NavigateUri="http://zlib.net/zlib_license.html">zlib license</Hyperlink>
                             <LineBreak />
                         </TextBlock>

--- a/app/VLC.Universal/Views/VariousPages/AboutPage.xaml
+++ b/app/VLC.Universal/Views/VariousPages/AboutPage.xaml
@@ -41,7 +41,7 @@
                             <Run Text="The sources to this application can be retrieved at http://code.videolan.org/videolan/vlc-winrt" />
                             <LineBreak />
                             <Run Text="If you want to manually deploy the package by yourself, without having to pay for a Dev License, follow the steps in this link:" />
-                            <Hyperlink Foreground="DarkOrange" 
+                            <Hyperlink Foreground="AccentColor" 
                                        NavigateUri="https://msdn.microsoft.com/en-us/library/windows/apps/dn614128.aspx">Msdn library</Hyperlink>
                             <LineBreak />
                             <LineBreak />
@@ -51,133 +51,133 @@
                             <Run Text="Some VLC plugins use external libraries that make extensive use of the following persons' or companies' code:" />
                             <LineBreak />
                             <Run Text="FFmpeg/Libav - Copyright ; 2000-2010 the FFmpeg developers -" /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="FLAC - Copyright (c) 2001-2012 Josh Coalson et al. - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <Run Text=", codec libs" /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="#xiph">Xiph.org BSD license</Hyperlink>
                             <LineBreak />
                             <Run Text="Freetype2 - Copyright (c) 2006-2011 by David Turner, Robert Wilhelm, and Werner Lemberg. - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="Fribidi - Copyright (c) Behdad Esfahbod - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="GnuTLS - Copyright (c) 2000-2012 Free Software Foundation - " />
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-3.0.txt">GPL v3 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="GOOM! - Copyright (c) 2000-2004 Jean-Christophe Hoelt - " />
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="GSM - Copyright (c) 1992-1994 Jutta Degener &amp; Carsten Bormann - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="#gsm">GSM permissive license</Hyperlink>
                             <LineBreak />
                             <Run Text="liba52 - Copyright (c) Aaron Holtzman, Michel Lespinasse, et al. - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libass - Copyright (c) Evgeniy Stepanov, Grigori Goronzy, et al. - " />
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://opensource.org/licenses/ISC">ISC license</Hyperlink>
                             <LineBreak />
                             <Run Text="libdca - Copyright (c) Gildas Bazin, Sam Hocevar, et al. - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libdvbpsi - Copyright (c) 2001-2010 VideoLAN - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libebml - Copyright (c) 2002-2010 Steve Lhomme - " />
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libgcrypt - Copyright (c) 2000-2012 Free Software Foundation. - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libgpg-error - Copyright (c) 2003 g10 Code GmbH - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libiconv - Copyright (c) 1999-2001 Free Software Foundation - " />
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libmad - Copyright (c) 2000-2004 Underbit Technologies, Inc. - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libmatroska - Copyright (c) 2002-2003 Steve Lhomme - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libmodplug - Olivier Lapicque, Konstanty - " />
                             <Italic>Public domain</Italic>
                             <LineBreak />
                             <Run Text="libmpeg2 - Copyright (c) 1999-2012 Sam Hocevar, Aaron Holtzman, Michel Lespinasse, Christophe Massiot, et al. - " />
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libogg - Copyright (c) 2002 Xiph.org Foundation - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="#xiph">Xiph.org BSD license</Hyperlink>
                             <LineBreak />
                             <Run Text="libpng - Copyright (c) 2004,2006-2012 Glenn Randers-Pehrson, et al. - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.libpng.org/pub/png/src/libpng-LICENSE.txt">libpng license</Hyperlink>
                             <LineBreak />
                             <Run Text="libpostproc - Copyright (c) 2001-2003 Michael Niedermayer - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/gpl-2.0.txt">GPL v2 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="libtheora - Copyright (c) Xiph.org - " />
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="#xiph">Xiph.org BSD license</Hyperlink>
                             <LineBreak />
                             <Run Text="libxml2 - Copyright (c) 1998-2003 Daniel Veillard - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.opensource.org/licenses/mit-license.php">MIT license</Hyperlink>
                             <LineBreak />
                             <Run Text="live555 - Copyright (c) 1996-2012 Live Networks, Inc - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="Lua - Copyright (c) 1994-2008 Lua.org - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.opensource.org/licenses/mit-license.php">MIT license</Hyperlink>
                             <LineBreak />
                             <Run Text="Openjpeg - Copyright (c) 2002-2012, Communications and Remote Sensing Laboratory, UCL, Belgium - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://opensource.org/licenses/ISC">ISC license</Hyperlink>
                             <LineBreak />
                             <Run Text="ORC - Copyright (c) 2002-2009 David A. Schleef - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://opensource.org/licenses/ISC">ISC license</Hyperlink>
                             <LineBreak />
                             <Run Text="Schroedinger - Copyright (c) David Schleef, W.J. van der Laan - " />
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.opensource.org/licenses/mit-license.php">MIT license</Hyperlink>
                             <LineBreak />
                             <Run Text="Speex, Speexdsp - Copyright (c) 1992-2008 Xiph.org Foundation, Jean-Marc Valin, Analog Devices Inc, Commonwealth Scientific and Industrial Research Organisation, David Rowe, Jutta Degener, Carsten Bormann - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.opensource.org/licenses/BSD-3-Clause">3-clause BSD license</Hyperlink>
                             <LineBreak />
                             <Run Text="Taglib - Copyright (c) 2002-2008 Scott Wheeler, et al. - " />
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://www.gnu.org/licenses/lgpl-2.1.txt">LGPL v2.1 or later</Hyperlink>
                             <LineBreak />
                             <Run Text="Zlib - Copyright (c) 1995-2012 Jean-loup Gailly and Mark Adler - " /> 
-                            <Hyperlink Foreground="DarkOrange"
+                            <Hyperlink Foreground="AccentColor"
                                        NavigateUri="http://zlib.net/zlib_license.html">zlib license</Hyperlink>
                             <LineBreak />
                         </TextBlock>


### PR DESCRIPTION
This is to fix issue #262 one day. Sorry for not realizing that this mirror is active (can be used for PRs) too. 

I consider the following TODOs which I will try to implement in the next few weeks:

- [x] fix link in about page not visible in dark mode
- [x] use accent color for links in about page too
- [x] fix consistency of dark on light / light on dark depending on mode
- [ ] use Windows wide color preferences as default

For the moment I will try to get it running at all. Which [nightly](http://nightlies.videolan.org/build/winrt-x86_64) build is stable enough so I know that errors while building are because of a misconfiguration on my side and not because of nightly-issues?
