### PR TITLE
Fixed possibility to go beyond the border values in video settings.

### DIFF
--- a/app/VLC.Core/Commands/MediaPlayback/ChangeAudioDelayCommand.cs
+++ b/app/VLC.Core/Commands/MediaPlayback/ChangeAudioDelayCommand.cs
@@ -6,6 +6,8 @@ namespace VLC.Commands.MediaPlayback
 {
     public class ChangeAudioDelayCommand : AlwaysExecutableCommand
     {
+        private int limit = 3000;
+        private int step = 50;
         public override void Execute(object parameter)
         {
             if (Locator.MediaPlaybackViewModel.PlaybackService.PlayingType == PlayingType.NotPlaying)
@@ -15,15 +17,17 @@ namespace VLC.Commands.MediaPlayback
             switch (request)
             {
                 case "faster":
-                    if (Locator.MediaPlaybackViewModel.AudioDelay < 3000)
+                    Locator.MediaPlaybackViewModel.AudioDelay += step;
+                    if (Locator.MediaPlaybackViewModel.AudioDelay > limit)
                     {
-                        Locator.MediaPlaybackViewModel.AudioDelay += 50;
+                        Locator.MediaPlaybackViewModel.AudioDelay = limit;
                     }
                     break;
                 case "slower":
-                    if (Locator.MediaPlaybackViewModel.AudioDelay > -3000)
+                    Locator.MediaPlaybackViewModel.AudioDelay -= step;
+                    if (Locator.MediaPlaybackViewModel.AudioDelay < -limit)
                     {
-                        Locator.MediaPlaybackViewModel.AudioDelay -= 50;
+                        Locator.MediaPlaybackViewModel.AudioDelay = -limit;
                     }
                     break;
                 case "reset":

--- a/app/VLC.Core/Commands/MediaPlayback/ChangeSpuDelayCommand.cs
+++ b/app/VLC.Core/Commands/MediaPlayback/ChangeSpuDelayCommand.cs
@@ -6,6 +6,8 @@ namespace VLC.Commands.MediaPlayback
 {
     public class ChangeSpuDelayCommand : AlwaysExecutableCommand
     {
+        private int limit = 3000;
+        private int step = 50;
         public override void Execute(object parameter)
         {
             if (Locator.MediaPlaybackViewModel.PlaybackService.PlayingType == PlayingType.NotPlaying)
@@ -15,15 +17,17 @@ namespace VLC.Commands.MediaPlayback
             switch (request)
             {
                 case "faster":
-                    if (Locator.MediaPlaybackViewModel.SpuDelay < 3000)
+                    Locator.MediaPlaybackViewModel.SpuDelay += step;
+                    if (Locator.MediaPlaybackViewModel.SpuDelay > limit)
                     {
-                        Locator.MediaPlaybackViewModel.SpuDelay += 50;
+                        Locator.MediaPlaybackViewModel.SpuDelay = limit;
                     }
                     break;
                 case "slower":
-                    if (Locator.MediaPlaybackViewModel.SpuDelay > -3000)
+                    Locator.MediaPlaybackViewModel.SpuDelay -= step;
+                    if (Locator.MediaPlaybackViewModel.SpuDelay < -limit)
                     {
-                        Locator.MediaPlaybackViewModel.SpuDelay -= 50;
+                        Locator.MediaPlaybackViewModel.SpuDelay = -limit;
                     }
                     break;
                 case "reset":

--- a/app/VLC.Core/Services/RunTime/PlaybackService.cs
+++ b/app/VLC.Core/Services/RunTime/PlaybackService.cs
@@ -382,13 +382,15 @@ namespace VLC.Services.RunTime
 
         public long AudioDelay
         {
-            get { return _mediaPlayer.audioDelay(); }
-            set { _mediaPlayer.setAudioDelay(value); }
+            // LibVLC works with microseconds, so we should multiply the values by 1000.
+            get { return _mediaPlayer.audioDelay() / 1000; }
+            set { _mediaPlayer.setAudioDelay(value * 1000); }
         }
 
         public long SpuDelay
         {
-            get { return _mediaPlayer.spuDelay(); }
+            // LibVLC works with microseconds, so we should multiply the values by 1000.
+            get { return _mediaPlayer.spuDelay() / 1000; }
             set { _mediaPlayer.setSpuDelay(value * 1000); }
         }
 


### PR DESCRIPTION
This PR fixes a couple bugs in playback settings window.

If user sets a value of the audio delay (or the subtitle delay) on a slider (for example 15) and after this increases the value by `+` button, in the end he will get 3015 ms instead of 3000.
Visual gif is below.

And the second bug is related to the subtitle delay. It's completely broken, the value must not be multiplied by 1000.
Even though this issue is fixed by single line, I split the PR into two commits because I think it's another bug not related to the previous one.   

Both issues are reproduced in Xbox.

By the way, I replaced the repeated numbers with int variables. This will make it easier to change steps and limits in the future.

![heh3](https://user-images.githubusercontent.com/4051126/52598929-42944300-2e68-11e9-8c5e-d13e5f68d154.gif)
