### PR TITLE
Translation updates and PT-BR+RO

### DIFF
--- a/app/VLC.Universal/MultilingualResources/VLC.Universal.es-ES.xlf
+++ b/app/VLC.Universal/MultilingualResources/VLC.Universal.es-ES.xlf
@@ -212,7 +212,7 @@
         </trans-unit>
         <trans-unit id="IncreaseVolume" translate="yes" xml:space="preserve">
           <source>increase volume</source>
-          <target state="translated">incrementar volumen</target>
+          <target state="translated">subir volumen</target>
         </trans-unit>
         <trans-unit id="ItsEmpty" translate="yes" xml:space="preserve">
           <source>it's empty here</source>

--- a/app/VLC.Universal/MultilingualResources/VLC.Universal.ko-KR.xlf
+++ b/app/VLC.Universal/MultilingualResources/VLC.Universal.ko-KR.xlf
@@ -404,7 +404,7 @@
         </trans-unit>
         <trans-unit id="PlaylistAlreadyExists" translate="yes" xml:space="preserve">
           <source>this playlist already exists</source>
-          <target state="translated">이 아티스트는 이미 있습니다</target>
+          <target state="translated">이 아티스트는 이미 존재합니다</target>
         </trans-unit>
         <trans-unit id="PlaylistNamePlaceholder" translate="yes" xml:space="preserve">
           <source>playlist name</source>
@@ -576,7 +576,7 @@
         </trans-unit>
         <trans-unit id="VideoFolders" translate="yes" xml:space="preserve">
           <source>video folders</source>
-          <target state="translated">비디오 ㅍ더</target>
+          <target state="translated">비디오 폴더</target>
         </trans-unit>
         <trans-unit id="VideoFoldersDescription" translate="yes" xml:space="preserve">
           <source>VLC will only search videos that are in your video library. You can add folders to your library here</source>
@@ -948,7 +948,7 @@
         </trans-unit>
         <trans-unit id="AddMarginExplanation" translate="yes" xml:space="preserve">
           <source>Some TVs will not display the app correctly. To add some margin, turn this on</source>
-          <target state="translated">일부 TV는 앱을 제대로 표시하지 못합니다. 여백을 약간 추가하려면, 이걸 켜세요</target>
+          <target state="translated">일부 TV는 앱을 정상적으로 표시하지 못합니다. 이 기능으로 약간의 여백을 추가할 수 있습니다.</target>
         </trans-unit>
         <trans-unit id="ExtraMargin" translate="yes" xml:space="preserve">
           <source>Extra margin</source>

--- a/app/VLC.Universal/MultilingualResources/VLC.Universal.pt-BR.xlf
+++ b/app/VLC.Universal/MultilingualResources/VLC.Universal.pt-BR.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file build-num="n/a" datatype="xml" original="VLC.UNIVERSAL/STRINGS/EN-US/RESOURCES.RESW" product-name="n/a" product-version="n/a" source-language="en-US" target-language="pt_BR" tool-id="MultilingualAppToolkit">
+  <file build-num="n/a" datatype="xml" original="VLC.UNIVERSAL/STRINGS/EN-US/RESOURCES.RESW" product-name="n/a" product-version="n/a" source-language="en-US" target-language="pt-BR" tool-id="MultilingualAppToolkit">
     <header>
       <tool tool-company="Microsoft" tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1605.0" />
     </header>

--- a/app/VLC.Universal/MultilingualResources/VLC.Universal.pt-PT.xlf
+++ b/app/VLC.Universal/MultilingualResources/VLC.Universal.pt-PT.xlf
@@ -192,7 +192,7 @@
         </trans-unit>
         <trans-unit id="HoweverYouMayFindWhatYouWantHere" translate="yes" xml:space="preserve">
           <source>however you may find what you're looking for here</source>
-          <target state="translated">contudo você pode encontrar o que procura aqui</target>
+          <target state="translated">contudo pode encontrar o que procura aqui</target>
         </trans-unit>
         <trans-unit id="HowToFavoriteAlbum1" translate="yes" xml:space="preserve">
           <source>to favorite an album, just press</source>
@@ -256,7 +256,7 @@
         </trans-unit>
         <trans-unit id="MusicShows" translate="yes" xml:space="preserve">
           <source>music shows</source>
-          <target state="translated">Shows de música</target>
+          <target state="translated">Programas de música</target>
         </trans-unit>
         <trans-unit id="Mute" translate="yes" xml:space="preserve">
           <source>mute</source>
@@ -288,7 +288,7 @@
         </trans-unit>
         <trans-unit id="NoCameraVideosFound" translate="yes" xml:space="preserve">
           <source>no camera videos found</source>
-          <target state="translated">não foram encontrados vídeos de câmera</target>
+          <target state="translated">não foram encontrados vídeos de câmara</target>
         </trans-unit>
         <trans-unit id="NoFavoriteAlbums" translate="yes" xml:space="preserve">
           <source>no favorite albums</source>
@@ -572,7 +572,7 @@
         </trans-unit>
         <trans-unit id="Video" translate="yes" xml:space="preserve">
           <source>video</source>
-          <target state="translated">video</target>
+          <target state="translated">vídeo</target>
         </trans-unit>
         <trans-unit id="VideoFolders" translate="yes" xml:space="preserve">
           <source>video folders</source>
@@ -948,7 +948,7 @@
         </trans-unit>
         <trans-unit id="AddMarginExplanation" translate="yes" xml:space="preserve">
           <source>Some TVs will not display the app correctly. To add some margin, turn this on</source>
-          <target state="translated">Algumas TVs não mostrarão a app correctamente. Para adicionar alguma margem, active isto</target>
+          <target state="translated">Algumas TVs não mostrarão a app corretamente. Para adicionar alguma margem, ative isto</target>
         </trans-unit>
         <trans-unit id="ExtraMargin" translate="yes" xml:space="preserve">
           <source>Extra margin</source>

--- a/app/VLC.Universal/MultilingualResources/VLC.Universal.pt_BR.xlf
+++ b/app/VLC.Universal/MultilingualResources/VLC.Universal.pt_BR.xlf
@@ -1,0 +1,976 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file build-num="n/a" datatype="xml" original="VLC.UNIVERSAL/STRINGS/EN-US/RESOURCES.RESW" product-name="n/a" product-version="n/a" source-language="en-US" target-language="pt_BR" tool-id="MultilingualAppToolkit">
+    <header>
+      <tool tool-company="Microsoft" tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1605.0" />
+    </header>
+    <body>
+      <group datatype="resx" id="VLC.UNIVERSAL/STRINGS/EN-US/RESOURCES.RESW">
+        <trans-unit id="AboutTheApp" translate="yes" xml:space="preserve">
+          <source>about the app</source>
+          <target state="translated">Sobre o aplicativo</target>
+        </trans-unit>
+        <trans-unit id="Add" translate="yes" xml:space="preserve">
+          <source>add</source>
+          <target state="translated">adicionar</target>
+        </trans-unit>
+        <trans-unit id="AddFolder" translate="yes" xml:space="preserve">
+          <source>add folder</source>
+          <target state="translated">adicionar pasta</target>
+        </trans-unit>
+        <trans-unit id="AddToCollection" translate="yes" xml:space="preserve">
+          <source>add to collection</source>
+          <target state="translated">adicionar à coleção</target>
+        </trans-unit>
+        <trans-unit id="AddToCurrentPlaylist" translate="yes" xml:space="preserve">
+          <source>add to current playlist</source>
+          <target state="translated">adicionar à lista de reprodução atual</target>
+        </trans-unit>
+        <trans-unit id="AddToPlaylist" translate="yes" xml:space="preserve">
+          <source>add to playlist</source>
+          <target state="translated">Adicionar à lista de reprodução</target>
+        </trans-unit>
+        <trans-unit id="Albums" translate="yes" xml:space="preserve">
+          <source>albums</source>
+          <target state="translated">álbuns</target>
+        </trans-unit>
+        <trans-unit id="AlbumsFound" translate="yes" xml:space="preserve">
+          <source>albums found : {0}</source>
+          <target state="translated">álbuns encontrados : {0}</target>
+        </trans-unit>
+        <trans-unit id="Animations" translate="yes" xml:space="preserve">
+          <source>animations</source>
+          <target state="translated">animações</target>
+        </trans-unit>
+        <trans-unit id="AppTheme" translate="yes" xml:space="preserve">
+          <source>application theme</source>
+          <target state="translated">tema do aplicativo</target>
+        </trans-unit>
+        <trans-unit id="Artists" translate="yes" xml:space="preserve">
+          <source>artists</source>
+          <target state="translated">artistas</target>
+        </trans-unit>
+        <trans-unit id="Audio" translate="yes" xml:space="preserve">
+          <source>audio</source>
+          <target state="translated">áudio</target>
+        </trans-unit>
+        <trans-unit id="AudioDelay" translate="yes" xml:space="preserve">
+          <source>audio delay</source>
+          <target state="translated">atraso do áudio</target>
+        </trans-unit>
+        <trans-unit id="AudioTracks" translate="yes" xml:space="preserve">
+          <source>Audio Tracks</source>
+          <target state="translated">Trilhas de Áudio</target>
+        </trans-unit>
+        <trans-unit id="Back" translate="yes" xml:space="preserve">
+          <source>back</source>
+          <target state="translated">voltar</target>
+        </trans-unit>
+        <trans-unit id="CameraRoll" translate="yes" xml:space="preserve">
+          <source>camera roll</source>
+          <target state="translated">rolo de filme</target>
+        </trans-unit>
+        <trans-unit id="ChangeAlbumCover" translate="yes" xml:space="preserve">
+          <source>change album cover</source>
+          <target state="translated">mudar capa</target>
+        </trans-unit>
+        <trans-unit id="Chapters" translate="yes" xml:space="preserve">
+          <source>Chapters</source>
+          <target state="translated">Capítulos</target>
+        </trans-unit>
+        <trans-unit id="CheckCredentials" translate="yes" xml:space="preserve">
+          <source>an error occured, please check your credentials</source>
+          <target state="translated">Ocorreu um erro. Por favor verifique as suas credenciais</target>
+        </trans-unit>
+        <trans-unit id="Connect" translate="yes" xml:space="preserve">
+          <source>connect</source>
+          <target state="translated">conectar</target>
+        </trans-unit>
+        <trans-unit id="ConnectedToLastFM" translate="yes" xml:space="preserve">
+          <source>connected to Last.FM</source>
+          <target state="translated">conectado ao Last.FM</target>
+        </trans-unit>
+        <trans-unit id="Connecting" translate="yes" xml:space="preserve">
+          <source>connecting</source>
+          <target state="translated">conectando</target>
+        </trans-unit>
+        <trans-unit id="ConnectToLastFM" translate="yes" xml:space="preserve">
+          <source>connect to Last.FM</source>
+          <target state="translated">conectar ao Last.FM</target>
+        </trans-unit>
+        <trans-unit id="CrashReport" translate="yes" xml:space="preserve">
+          <source>crash report</source>
+          <target state="translated">relatório de falhas</target>
+        </trans-unit>
+        <trans-unit id="DecreaseSpeed" translate="yes" xml:space="preserve">
+          <source>decrease speed</source>
+          <target state="translated">reduzir velocidade</target>
+        </trans-unit>
+        <trans-unit id="DecreaseVolume" translate="yes" xml:space="preserve">
+          <source>decrease volume</source>
+          <target state="translated">diminuir volume</target>
+        </trans-unit>
+        <trans-unit id="DeletePlaylist" translate="yes" xml:space="preserve">
+          <source>delete playlist</source>
+          <target state="translated">excluir lista de reprodução</target>
+        </trans-unit>
+        <trans-unit id="DeleteSelected" translate="yes" xml:space="preserve">
+          <source>delete selected</source>
+          <target state="translated">excluir o item selecionado</target>
+        </trans-unit>
+        <trans-unit id="EditMetadata" translate="yes" xml:space="preserve">
+          <source>edit metadata</source>
+          <target state="translated">editar metadados</target>
+        </trans-unit>
+        <trans-unit id="ElementsNotFound" translate="yes" xml:space="preserve">
+          <source>we did not find elements in there</source>
+          <target state="translated">não foram encontrados elementos aqui</target>
+        </trans-unit>
+        <trans-unit id="EnterURL" translate="yes" xml:space="preserve">
+          <source>enter a url</source>
+          <target state="translated">digite a url</target>
+        </trans-unit>
+        <trans-unit id="Episode" translate="yes" xml:space="preserve">
+          <source>episode</source>
+          <target state="translated">episódio</target>
+        </trans-unit>
+        <trans-unit id="EvenIfBackground" translate="yes" xml:space="preserve">
+          <source>even if the app is in background</source>
+          <target state="translated">mesmo se o aplicativo estiver em segundo plano</target>
+        </trans-unit>
+        <trans-unit id="EvenIfNotBackground" translate="yes" xml:space="preserve">
+          <source>even if the app is not in background</source>
+          <target state="translated">mesmo se o aplicativo não estiver em segundo plano</target>
+        </trans-unit>
+        <trans-unit id="FailFilePlayBackground" translate="yes" xml:space="preserve">
+          <source>This file may not play in the background</source>
+          <target state="translated">Este arquivo não pode ser reproduzido em segundo plano</target>
+        </trans-unit>
+        <trans-unit id="FailNavigateVideoPlayerPage" translate="yes" xml:space="preserve">
+          <source>VLC failed to navigate to the Video Player page</source>
+          <target state="translated">O VLC não pôde navegar na página do Reprodutor de Vídeos</target>
+        </trans-unit>
+        <trans-unit id="FailOpenVideo" translate="yes" xml:space="preserve">
+          <source>VLC failed to open the video</source>
+          <target state="translated">O VLC não pôde abrir o vídeo</target>
+        </trans-unit>
+        <trans-unit id="FailStartVLCEngine" translate="yes" xml:space="preserve">
+          <source>The app failed to start the VLC engine</source>
+          <target state="translated">O aplicativo falhou ao iniciar o mecanismo do VLC</target>
+        </trans-unit>
+        <trans-unit id="FeedbackThankYou" translate="yes" xml:space="preserve">
+          <source>feedback sent! thank you</source>
+          <target state="translated">sugestão enviada! Obrigado</target>
+        </trans-unit>
+        <trans-unit id="FileExplorer" translate="yes" xml:space="preserve">
+          <source>browse</source>
+          <target state="translated">procurar</target>
+        </trans-unit>
+        <trans-unit id="HardwareDecoding" translate="yes" xml:space="preserve">
+          <source>hardware decoding</source>
+          <target state="translated">dispositivo de decodificação</target>
+        </trans-unit>
+        <trans-unit id="HardwareDecodingDescription" translate="yes" xml:space="preserve">
+          <source>Hardware decoding may not work on your device.</source>
+          <target state="translated">O dispositivo de decodificação pode não funcionar no seu aparelho.</target>
+        </trans-unit>
+        <trans-unit id="HaveToSelectPlaylist" translate="yes" xml:space="preserve">
+          <source>please select a playlist</source>
+          <target state="translated">por favor selecione uma lista de reprodução</target>
+        </trans-unit>
+        <trans-unit id="Home" translate="yes" xml:space="preserve">
+          <source>home</source>
+          <target state="translated">início</target>
+        </trans-unit>
+        <trans-unit id="HomePage" translate="yes" xml:space="preserve">
+          <source>home page</source>
+          <target state="translated">página inicial</target>
+        </trans-unit>
+        <trans-unit id="HomePageDescription" translate="yes" xml:space="preserve">
+          <source>VLC will start on the selected page</source>
+          <target state="translated">O VLC iniciará na página selecionada</target>
+        </trans-unit>
+        <trans-unit id="HoweverYouMayFindWhatYouWantHere" translate="yes" xml:space="preserve">
+          <source>however you may find what you're looking for here</source>
+          <target state="translated">entretanto você pode encontrar o que procura aqui</target>
+        </trans-unit>
+        <trans-unit id="HowToFavoriteAlbum1" translate="yes" xml:space="preserve">
+          <source>to favorite an album, just press</source>
+          <target state="translated">para tornar um álbum favorito, basta pressionar</target>
+        </trans-unit>
+        <trans-unit id="HowToFavoriteAlbum2" translate="yes" xml:space="preserve">
+          <source>and you'll get an instant access to it</source>
+          <target state="translated">e obterá um acesso instantâneo</target>
+        </trans-unit>
+        <trans-unit id="ImportantSponsors" translate="yes" xml:space="preserve">
+          <source>important sponsors</source>
+          <target state="translated">sensores importantes</target>
+        </trans-unit>
+        <trans-unit id="IncreaseSpeed" translate="yes" xml:space="preserve">
+          <source>increase speed</source>
+          <target state="translated">aumentar velocidade</target>
+        </trans-unit>
+        <trans-unit id="IncreaseVolume" translate="yes" xml:space="preserve">
+          <source>increase volume</source>
+          <target state="translated">aumentar volume</target>
+        </trans-unit>
+        <trans-unit id="ItsEmpty" translate="yes" xml:space="preserve">
+          <source>it's empty here</source>
+          <target state="translated">está vazio aqui</target>
+        </trans-unit>
+        <trans-unit id="KeyboardShortcuts" translate="yes" xml:space="preserve">
+          <source>keyboard shortcuts</source>
+          <target state="translated">atalhos de teclado</target>
+        </trans-unit>
+        <trans-unit id="License" translate="yes" xml:space="preserve">
+          <source>license</source>
+          <target state="translated">licença</target>
+        </trans-unit>
+        <trans-unit id="Loading" translate="yes" xml:space="preserve">
+          <source>loading</source>
+          <target state="translated">carregando</target>
+        </trans-unit>
+        <trans-unit id="LoadingMusic" translate="yes" xml:space="preserve">
+          <source>loading music</source>
+          <target state="translated">carregando música</target>
+        </trans-unit>
+        <trans-unit id="MostPlayedArtists" translate="yes" xml:space="preserve">
+          <source>most played artists</source>
+          <target state="translated">artistas mais reproduzidos</target>
+        </trans-unit>
+        <trans-unit id="Music" translate="yes" xml:space="preserve">
+          <source>music</source>
+          <target state="translated">música</target>
+        </trans-unit>
+        <trans-unit id="MusicFolders" translate="yes" xml:space="preserve">
+          <source>music folders</source>
+          <target state="translated">pastas de músicas</target>
+        </trans-unit>
+        <trans-unit id="MusicFoldersDescription" translate="yes" xml:space="preserve">
+          <source>VLC will only search songs that are in your music library. You can add folders to your library here</source>
+          <target state="translated">O VLC somente procurará músicas que estão na sua biblioteca de músicas. Adicione pastas à sua biblioteca aqui:</target>
+        </trans-unit>
+        <trans-unit id="MusicSettings" translate="yes" xml:space="preserve">
+          <source>Music Settings</source>
+          <target state="translated">Configurações de Músicas</target>
+        </trans-unit>
+        <trans-unit id="MusicShows" translate="yes" xml:space="preserve">
+          <source>music shows</source>
+          <target state="translated">espetáculos musicais</target>
+        </trans-unit>
+        <trans-unit id="Mute" translate="yes" xml:space="preserve">
+          <source>mute</source>
+          <target state="translated">sem áudio</target>
+        </trans-unit>
+        <trans-unit id="MyPlaylists" translate="yes" xml:space="preserve">
+          <source>my playlists</source>
+          <target state="translated">minhas listas de reprodução</target>
+        </trans-unit>
+        <trans-unit id="Network" translate="yes" xml:space="preserve">
+          <source>network</source>
+          <target state="translated">rede</target>
+        </trans-unit>
+        <trans-unit id="NewPlaylist" translate="yes" xml:space="preserve">
+          <source>new playlist</source>
+          <target state="translated">nova lista de reprodução</target>
+        </trans-unit>
+        <trans-unit id="NewVideos" translate="yes" xml:space="preserve">
+          <source>new videos</source>
+          <target state="translated">novos vídeos</target>
+        </trans-unit>
+        <trans-unit id="No" translate="yes" xml:space="preserve">
+          <source>no</source>
+          <target state="translated">não</target>
+        </trans-unit>
+        <trans-unit id="NoBiographyFound" translate="yes" xml:space="preserve">
+          <source>no bio found for this artist</source>
+          <target state="translated">nenhuma biografia encontrada para este artista</target>
+        </trans-unit>
+        <trans-unit id="NoCameraVideosFound" translate="yes" xml:space="preserve">
+          <source>no camera videos found</source>
+          <target state="translated">nenhuma câmera de vídeo encontrada</target>
+        </trans-unit>
+        <trans-unit id="NoFavoriteAlbums" translate="yes" xml:space="preserve">
+          <source>no favorite albums</source>
+          <target state="translated">nenhum álbum favorito</target>
+        </trans-unit>
+        <trans-unit id="NoInternetConnection" translate="yes" xml:space="preserve">
+          <source>no internet connection</source>
+          <target state="translated">sem conexão com a Internet</target>
+        </trans-unit>
+        <trans-unit id="NoPlaylists" translate="yes" xml:space="preserve">
+          <source>no playlists</source>
+          <target state="translated">sem listas de reprodução</target>
+        </trans-unit>
+        <trans-unit id="NoShowsFound" translate="yes" xml:space="preserve">
+          <source>no shows found</source>
+          <target state="translated">nenhum espetáculo encontrado</target>
+        </trans-unit>
+        <trans-unit id="NothingToSeeHere" translate="yes" xml:space="preserve">
+          <source>there's nothing to see here</source>
+          <target state="translated">Nada para ver aqui</target>
+        </trans-unit>
+        <trans-unit id="Notifications" translate="yes" xml:space="preserve">
+          <source>notifications</source>
+          <target state="translated">notificações</target>
+        </trans-unit>
+        <trans-unit id="NotificationWhenSongStarts" translate="yes" xml:space="preserve">
+          <source>when the song starts</source>
+          <target state="translated">quando a música inicia</target>
+        </trans-unit>
+        <trans-unit id="NoVideosFound" translate="yes" xml:space="preserve">
+          <source>we did not find video</source>
+          <target state="translated">Não foram encontrados vídeos</target>
+        </trans-unit>
+        <trans-unit id="NowPlaying" translate="yes" xml:space="preserve">
+          <source>now playing</source>
+          <target state="translated">reproduzindo</target>
+        </trans-unit>
+        <trans-unit id="OpenFile" translate="yes" xml:space="preserve">
+          <source>open file</source>
+          <target state="translated">abrir arquivo</target>
+        </trans-unit>
+        <trans-unit id="OpenStream" translate="yes" xml:space="preserve">
+          <source>open stream</source>
+          <target state="translated">abrir fluxo de rede</target>
+        </trans-unit>
+        <trans-unit id="OpenSubtitle" translate="yes" xml:space="preserve">
+          <source>open subtitle</source>
+          <target state="translated">abrir legenda</target>
+        </trans-unit>
+        <trans-unit id="OrderAscending" translate="yes" xml:space="preserve">
+          <source>ascending</source>
+          <target state="translated">ascendente</target>
+        </trans-unit>
+        <trans-unit id="OrderByAlbum" translate="yes" xml:space="preserve">
+          <source>by album</source>
+          <target state="translated">por álbum</target>
+        </trans-unit>
+        <trans-unit id="OrderByArtist" translate="yes" xml:space="preserve">
+          <source>by artist</source>
+          <target state="translated">por artista</target>
+        </trans-unit>
+        <trans-unit id="OrderByDate" translate="yes" xml:space="preserve">
+          <source>by date</source>
+          <target state="translated">por data</target>
+        </trans-unit>
+        <trans-unit id="OrderDescending" translate="yes" xml:space="preserve">
+          <source>descending</source>
+          <target state="translated">descendente</target>
+        </trans-unit>
+        <trans-unit id="Password" translate="yes" xml:space="preserve">
+          <source>password</source>
+          <target state="translated">senha</target>
+        </trans-unit>
+        <trans-unit id="Pause" translate="yes" xml:space="preserve">
+          <source>pause</source>
+          <target state="translated">pausar</target>
+        </trans-unit>
+        <trans-unit id="PinAlbum" translate="yes" xml:space="preserve">
+          <source>pin album</source>
+          <target state="translated">pinar álbum</target>
+        </trans-unit>
+        <trans-unit id="PinArtist" translate="yes" xml:space="preserve">
+          <source>pin artist</source>
+          <target state="translated">pinar artista</target>
+        </trans-unit>
+        <trans-unit id="Play" translate="yes" xml:space="preserve">
+          <source>play</source>
+          <target state="translated">reproduzir</target>
+        </trans-unit>
+        <trans-unit id="PlayAlbum" translate="yes" xml:space="preserve">
+          <source>play album</source>
+          <target state="translated">reproduzir o álbum</target>
+        </trans-unit>
+        <trans-unit id="PlayAll" translate="yes" xml:space="preserve">
+          <source>play all</source>
+          <target state="translated">Reproduzir tudo</target>
+        </trans-unit>
+        <trans-unit id="Playback" translate="yes" xml:space="preserve">
+          <source>playback</source>
+          <target state="translated">reprodução</target>
+        </trans-unit>
+        <trans-unit id="PlayerSettings" translate="yes" xml:space="preserve">
+          <source>Player Settings</source>
+          <target state="translated">Configurações do Reprodutor</target>
+        </trans-unit>
+        <trans-unit id="PlayFolder" translate="yes" xml:space="preserve">
+          <source>play folder</source>
+          <target state="translated">reproduzir pasta</target>
+        </trans-unit>
+        <trans-unit id="Playlist" translate="yes" xml:space="preserve">
+          <source>playlist</source>
+          <target state="translated">lista de reprodução</target>
+        </trans-unit>
+        <trans-unit id="PlaylistAlreadyExists" translate="yes" xml:space="preserve">
+          <source>this playlist already exists</source>
+          <target state="translated">esta lista de reprodução já existe</target>
+        </trans-unit>
+        <trans-unit id="PlaylistNamePlaceholder" translate="yes" xml:space="preserve">
+          <source>playlist name</source>
+          <target state="translated">nome da lista de reprodução</target>
+        </trans-unit>
+        <trans-unit id="Playlists" translate="yes" xml:space="preserve">
+          <source>playlists</source>
+          <target state="translated">listas de reprodução</target>
+        </trans-unit>
+        <trans-unit id="PlayTrack" translate="yes" xml:space="preserve">
+          <source>play track</source>
+          <target state="translated">reproduzir trilha</target>
+        </trans-unit>
+        <trans-unit id="PlayVideo" translate="yes" xml:space="preserve">
+          <source>play video</source>
+          <target state="translated">reproduzir vídeo</target>
+        </trans-unit>
+        <trans-unit id="PrivacyStatement" translate="yes" xml:space="preserve">
+          <source>privacy statement</source>
+          <target state="translated">declaração de privacidade</target>
+        </trans-unit>
+        <trans-unit id="Favorites" translate="yes" xml:space="preserve">
+          <source>Favorites</source>
+          <target state="translated">Favoritos</target>
+        </trans-unit>
+        <trans-unit id="RefreshMusicLibrary" translate="yes" xml:space="preserve">
+          <source>refresh music library</source>
+          <target state="translated">atualizar biblioteca de músicas</target>
+        </trans-unit>
+        <trans-unit id="RefreshVideoLibrary" translate="yes" xml:space="preserve">
+          <source>refresh video library</source>
+          <target state="translated">atualizar biblioteca de vídeos</target>
+        </trans-unit>
+        <trans-unit id="RemovableStorage" translate="yes" xml:space="preserve">
+          <source>removable storage</source>
+          <target state="translated">armazenamento removível</target>
+        </trans-unit>
+        <trans-unit id="RemoveFolder" translate="yes" xml:space="preserve">
+          <source>remove folder</source>
+          <target state="translated">excluir pasta</target>
+        </trans-unit>
+        <trans-unit id="RemoveMusicFolderDescription" translate="yes" xml:space="preserve">
+          <source>If you don't want this folder in your Music library, you can remove it. It will affect all apps, not only VLC</source>
+          <target state="translated">Se não desejar esta pasta em sua Biblioteca de Músicas, é possível removê-la. Afetará todos os aplicativos, não somente o VLC</target>
+        </trans-unit>
+        <trans-unit id="RemoveVideoFolderDescription" translate="yes" xml:space="preserve">
+          <source>If you don't want this folder in your Video library, you can remove it. It will affect all apps, not only VLC</source>
+          <target state="translated">Se não desejar esta pasta em sua Biblioteca de Vídeos, é possível removê-la. Afetará todos os aplicativos, não somente o VLC</target>
+        </trans-unit>
+        <trans-unit id="Reset" translate="yes" xml:space="preserve">
+          <source>reset</source>
+          <target state="translated">restaurar</target>
+        </trans-unit>
+        <trans-unit id="ResetMusicDatabase" translate="yes" xml:space="preserve">
+          <source>reset music database</source>
+          <target state="translated">reiniciar o banco de dados de músicas</target>
+        </trans-unit>
+        <trans-unit id="ResetSpeed" translate="yes" xml:space="preserve">
+          <source>reset speed</source>
+          <target state="translated">restaurar velocidade</target>
+        </trans-unit>
+        <trans-unit id="RichAnimationsDescription" translate="yes" xml:space="preserve">
+          <source>Use rich animations in the slideshows</source>
+          <target state="translated">Usar animações ricas em apresentações</target>
+        </trans-unit>
+        <trans-unit id="Search" translate="yes" xml:space="preserve">
+          <source>search</source>
+          <target state="translated">procurar</target>
+        </trans-unit>
+        <trans-unit id="Season" translate="yes" xml:space="preserve">
+          <source>season</source>
+          <target state="translated">temporada</target>
+        </trans-unit>
+        <trans-unit id="Settings" translate="yes" xml:space="preserve">
+          <source>settings</source>
+          <target state="translated">configurações</target>
+        </trans-unit>
+        <trans-unit id="ShowPlaylist" translate="yes" xml:space="preserve">
+          <source>show playlist</source>
+          <target state="translated">exibir lista de reprodução</target>
+        </trans-unit>
+        <trans-unit id="Shows" translate="yes" xml:space="preserve">
+          <source>shows</source>
+          <target state="translated">apresentações</target>
+        </trans-unit>
+        <trans-unit id="Shuffle" translate="yes" xml:space="preserve">
+          <source>shuffle</source>
+          <target state="translated">aleatório</target>
+        </trans-unit>
+        <trans-unit id="Songs" translate="yes" xml:space="preserve">
+          <source>songs</source>
+          <target state="translated">músicas</target>
+        </trans-unit>
+        <trans-unit id="SpecialThanks" translate="yes" xml:space="preserve">
+          <source>special thanks</source>
+          <target state="translated">agradecimento especial</target>
+        </trans-unit>
+        <trans-unit id="Speed" translate="yes" xml:space="preserve">
+          <source>speed</source>
+          <target state="translated">velocidade</target>
+        </trans-unit>
+        <trans-unit id="Stop" translate="yes" xml:space="preserve">
+          <source>stop</source>
+          <target state="translated">parar</target>
+        </trans-unit>
+        <trans-unit id="SubtitleDelay" translate="yes" xml:space="preserve">
+          <source>subtitle delay</source>
+          <target state="translated">atraso de legenda</target>
+        </trans-unit>
+        <trans-unit id="Subtitles" translate="yes" xml:space="preserve">
+          <source>Subtitles</source>
+          <target state="translated">Legendas</target>
+        </trans-unit>
+        <trans-unit id="SubtitlesEncoding" translate="yes" xml:space="preserve">
+          <source>subtitles encoding</source>
+          <target state="translated">codificação de legendas</target>
+        </trans-unit>
+        <trans-unit id="Theme" translate="yes" xml:space="preserve">
+          <source>theme</source>
+          <target state="translated">tema</target>
+        </trans-unit>
+        <trans-unit id="TileRemoved" translate="yes" xml:space="preserve">
+          <source>tile removed</source>
+          <target state="translated">mosaico removido</target>
+        </trans-unit>
+        <trans-unit id="TopVideos" translate="yes" xml:space="preserve">
+          <source>top videos</source>
+          <target state="translated">vídeos mais vistos</target>
+        </trans-unit>
+        <trans-unit id="TrackAddedToYourPlaylist" translate="yes" xml:space="preserve">
+          <source>track added to the playlist</source>
+          <target state="translated">trilha adicionada à lista de reprodução</target>
+        </trans-unit>
+        <trans-unit id="TrackAlreadyExistsInPlaylist" translate="yes" xml:space="preserve">
+          <source>this track is already in that playlist</source>
+          <target state="translated">esta trilha já está na lista de reprodução</target>
+        </trans-unit>
+        <trans-unit id="Tracks" translate="yes" xml:space="preserve">
+          <source>tracks</source>
+          <target state="translated">trilhas</target>
+        </trans-unit>
+        <trans-unit id="UnknownAlbum" translate="yes" xml:space="preserve">
+          <source>Unknown album</source>
+          <target state="translated">álbum desconhecido</target>
+        </trans-unit>
+        <trans-unit id="UnknownArtist" translate="yes" xml:space="preserve">
+          <source>Unknown artist</source>
+          <target state="translated">artista desconhecido</target>
+        </trans-unit>
+        <trans-unit id="UnknownShow" translate="yes" xml:space="preserve">
+          <source>Unknown show</source>
+          <target state="translated">Espetáculo desconhecido</target>
+        </trans-unit>
+        <trans-unit id="UnknownTrack" translate="yes" xml:space="preserve">
+          <source>Unknown track</source>
+          <target state="translated">Trilha desconhecida</target>
+        </trans-unit>
+        <trans-unit id="UserInterface" translate="yes" xml:space="preserve">
+          <source>User Interface</source>
+          <target state="translated">Interface de Usuário</target>
+        </trans-unit>
+        <trans-unit id="Username" translate="yes" xml:space="preserve">
+          <source>username</source>
+          <target state="translated">nome de usuário</target>
+        </trans-unit>
+        <trans-unit id="Video" translate="yes" xml:space="preserve">
+          <source>video</source>
+          <target state="translated">vídeo</target>
+        </trans-unit>
+        <trans-unit id="VideoFolders" translate="yes" xml:space="preserve">
+          <source>video folders</source>
+          <target state="translated">pastas de vídeos</target>
+        </trans-unit>
+        <trans-unit id="VideoFoldersDescription" translate="yes" xml:space="preserve">
+          <source>VLC will only search videos that are in your video library. You can add folders to your library here</source>
+          <target state="translated">O VLC somente procurará vídeos que estão na sua biblioteca de vídeos. Adicione pastas à sua biblioteca aqui</target>
+        </trans-unit>
+        <trans-unit id="VideoPlayback" translate="yes" xml:space="preserve">
+          <source>video playback</source>
+          <target state="translated">reprodução de vídeo</target>
+        </trans-unit>
+        <trans-unit id="VideoPlaybackInBackground" translate="yes" xml:space="preserve">
+          <source>play video in background</source>
+          <target state="translated">reproduzir vídeo em segundo plano</target>
+        </trans-unit>
+        <trans-unit id="Videos" translate="yes" xml:space="preserve">
+          <source>videos</source>
+          <target state="translated">vídeos</target>
+        </trans-unit>
+        <trans-unit id="VideoSettings" translate="yes" xml:space="preserve">
+          <source>Video Settings</source>
+          <target state="translated">Configurações de Vídeo</target>
+        </trans-unit>
+        <trans-unit id="ViewAlbum" translate="yes" xml:space="preserve">
+          <source>view album</source>
+          <target state="translated">Exibir álbum</target>
+        </trans-unit>
+        <trans-unit id="ViewArtist" translate="yes" xml:space="preserve">
+          <source>view artist</source>
+          <target state="translated">exibir artista</target>
+        </trans-unit>
+        <trans-unit id="Volume" translate="yes" xml:space="preserve">
+          <source>volume</source>
+          <target state="translated">volume</target>
+        </trans-unit>
+        <trans-unit id="WeNeedYourHelp" translate="yes" xml:space="preserve">
+          <source>we need your help</source>
+          <target state="translated">Precisamos da sua ajuda</target>
+        </trans-unit>
+        <trans-unit id="Yes" translate="yes" xml:space="preserve">
+          <source>yes</source>
+          <target state="translated">sim</target>
+        </trans-unit>
+        <trans-unit id="YourMusic" translate="yes" xml:space="preserve">
+          <source>your music</source>
+          <target state="translated">sua música</target>
+        </trans-unit>
+        <trans-unit id="AccentColor" translate="yes" xml:space="preserve">
+          <source>accent color</source>
+          <target state="translated">cor do realce</target>
+        </trans-unit>
+        <trans-unit id="BackgroundColor" translate="yes" xml:space="preserve">
+          <source>background color</source>
+          <target state="translated">cor de fundo</target>
+        </trans-unit>
+        <trans-unit id="Dark" translate="yes" xml:space="preserve">
+          <source>dark</source>
+          <target state="translated">escuro</target>
+        </trans-unit>
+        <trans-unit id="Light" translate="yes" xml:space="preserve">
+          <source>light</source>
+          <target state="translated">claro</target>
+        </trans-unit>
+        <trans-unit id="TitleBar" translate="yes" xml:space="preserve">
+          <source>title bar</source>
+          <target state="translated">barra de título</target>
+        </trans-unit>
+        <trans-unit id="NeedRestart" translate="yes" xml:space="preserve">
+          <source>You need to restart the app to apply changes</source>
+          <target state="translated">É necessário reiniciar o aplicativo para aplicar as modificações</target>
+        </trans-unit>
+        <trans-unit id="Zoom" translate="yes" xml:space="preserve">
+          <source>zoom</source>
+          <target state="translated">aproximação</target>
+        </trans-unit>
+        <trans-unit id="AreYouSure" translate="yes" xml:space="preserve">
+          <source>are you sure?</source>
+          <target state="translated">tem certeza?</target>
+        </trans-unit>
+        <trans-unit id="MediaCantBeRead" translate="yes" xml:space="preserve">
+          <source>the media can't be read</source>
+          <target state="translated">a mídia não pode ser lida</target>
+        </trans-unit>
+        <trans-unit id="Sorry" translate="yes" xml:space="preserve">
+          <source>we're sorry</source>
+          <target state="translated">pedimos desculpas</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_BEST_FIT" translate="yes" xml:space="preserve">
+          <source>best fit</source>
+          <target state="translated">melhor enquadramento</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_FIT_HORIZONTAL" translate="yes" xml:space="preserve">
+          <source>horizontal cropping</source>
+          <target state="translated">recorte horizontal</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_FIT_VERTICAL" translate="yes" xml:space="preserve">
+          <source>vertical cropping</source>
+          <target state="translated">recorte vertical</target>
+        </trans-unit>
+        <trans-unit id="YourPlaylistWontBeAccessible" translate="yes" xml:space="preserve">
+          <source>your playlist won't be accessible</source>
+          <target state="translated">sua lista de reprodução não é acessível</target>
+        </trans-unit>
+        <trans-unit id="NoArtistShowsFound" translate="yes" xml:space="preserve">
+          <source>we didn't find shows for this artist</source>
+          <target state="translated">Não foram encontrados espetáculos desse artista</target>
+        </trans-unit>
+        <trans-unit id="NoResults" translate="yes" xml:space="preserve">
+          <source>no results</source>
+          <target state="translated">sem resultados</target>
+        </trans-unit>
+        <trans-unit id="ForceLandscape" translate="yes" xml:space="preserve">
+          <source>Force landscape</source>
+          <target state="translated">Impor paisagem</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_STRETCH" translate="yes" xml:space="preserve">
+          <source>stretch</source>
+          <target state="translated">ajustar</target>
+        </trans-unit>
+        <trans-unit id="SimilarArtists" translate="yes" xml:space="preserve">
+          <source>Similar artists</source>
+          <target state="translated">Artistas similares</target>
+        </trans-unit>
+        <trans-unit id="EnglishLanguage" translate="yes" xml:space="preserve">
+          <source>English</source>
+          <target state="translated">Inglês</target>
+        </trans-unit>
+        <trans-unit id="FrenchLanguage" translate="yes" xml:space="preserve">
+          <source>French</source>
+          <target state="translated">Francês</target>
+        </trans-unit>
+        <trans-unit id="JapaneseLanguage" translate="yes" xml:space="preserve">
+          <source>Japanese</source>
+          <target state="translated">Japonês</target>
+        </trans-unit>
+        <trans-unit id="GermanLanguage" translate="yes" xml:space="preserve">
+          <source>German</source>
+          <target state="translated">Alemão</target>
+        </trans-unit>
+        <trans-unit id="PolishLanguage" translate="yes" xml:space="preserve">
+          <source>Polish</source>
+          <target state="translated">Polonês</target>
+        </trans-unit>
+        <trans-unit id="SlovakLanguage" translate="yes" xml:space="preserve">
+          <source>Slovak</source>
+          <target state="translated">Eslovaco</target>
+        </trans-unit>
+        <trans-unit id="DanishLanguage" translate="yes" xml:space="preserve">
+          <source>Danish</source>
+          <target state="translated">Dinamarquês</target>
+        </trans-unit>
+        <trans-unit id="SpanishLanguage" translate="yes" xml:space="preserve">
+          <source>Spanish</source>
+          <target state="translated">Espanhol</target>
+        </trans-unit>
+        <trans-unit id="HungarianLanguage" translate="yes" xml:space="preserve">
+          <source>Hungarian</source>
+          <target state="translated">Húngaro</target>
+        </trans-unit>
+        <trans-unit id="ItalianLanguage" translate="yes" xml:space="preserve">
+          <source>Italian</source>
+          <target state="translated">Italiano</target>
+        </trans-unit>
+        <trans-unit id="KoreanLanguage" translate="yes" xml:space="preserve">
+          <source>Korean</source>
+          <target state="translated">Coreano</target>
+        </trans-unit>
+        <trans-unit id="MalayLanguage" translate="yes" xml:space="preserve">
+          <source>Malay</source>
+          <target state="translated">Malaio</target>
+        </trans-unit>
+        <trans-unit id="NorwegianLanguage" translate="yes" xml:space="preserve">
+          <source>Norwegian</source>
+          <target state="translated">Norueguês</target>
+        </trans-unit>
+        <trans-unit id="DutchLanguage" translate="yes" xml:space="preserve">
+          <source>Dutch</source>
+          <target state="translated">Holandês</target>
+        </trans-unit>
+        <trans-unit id="RussianLanguage" translate="yes" xml:space="preserve">
+          <source>Russian</source>
+          <target state="translated">Russo</target>
+        </trans-unit>
+        <trans-unit id="SwedishLanguage" translate="yes" xml:space="preserve">
+          <source>Swedish</source>
+          <target state="translated">Sueco</target>
+        </trans-unit>
+        <trans-unit id="TurkishLanguage" translate="yes" xml:space="preserve">
+          <source>Turkish</source>
+          <target state="translated">Turco</target>
+        </trans-unit>
+        <trans-unit id="UkrainianLanguage" translate="yes" xml:space="preserve">
+          <source>Ukrainian</source>
+          <target state="translated">Ucraniano</target>
+        </trans-unit>
+        <trans-unit id="ChineseLanguage" translate="yes" xml:space="preserve">
+          <source>Chinese</source>
+          <target state="translated">Chinês</target>
+        </trans-unit>
+        <trans-unit id="PortugueseLanguage" translate="yes" xml:space="preserve">
+          <source>Portuguese</source>
+          <target state="translated">Português</target>
+        </trans-unit>
+        <trans-unit id="CzechLanguage" translate="yes" xml:space="preserve">
+          <source>Czech</source>
+          <target state="translated">Tcheco</target>
+        </trans-unit>
+        <trans-unit id="IcelandicLanguage" translate="yes" xml:space="preserve">
+          <source>Icelandic</source>
+          <target state="translated">Islandês</target>
+        </trans-unit>
+        <trans-unit id="HebrewLanguage" translate="yes" xml:space="preserve">
+          <source>Hebrew</source>
+          <target state="translated">Hebraico</target>
+        </trans-unit>
+        <trans-unit id="Languages" translate="yes" xml:space="preserve">
+          <source>Languages</source>
+          <target state="translated">Idiomas</target>
+        </trans-unit>
+        <trans-unit id="SelectLanguageDescription" translate="yes" xml:space="preserve">
+          <source>VLC will be displayed in</source>
+          <target state="translated">O VLC será exibido em</target>
+        </trans-unit>
+        <trans-unit id="ApplyAndRestart" translate="yes" xml:space="preserve">
+          <source>Apply And Restart</source>
+          <target state="translated">Aplicar e Reiniciar</target>
+        </trans-unit>
+        <trans-unit id="RefreshLanguage" translate="yes" xml:space="preserve">
+          <source>Refresh Language</source>
+          <target state="translated">Atualizar Idiomas</target>
+        </trans-unit>
+        <trans-unit id="Local" translate="yes" xml:space="preserve">
+          <source>local</source>
+          <target state="translated">local</target>
+        </trans-unit>
+        <trans-unit id="WEBINTF_DOWNLOADFILES" translate="yes" xml:space="preserve">
+          <source>Download Files</source>
+          <target state="translated">Baixar Arquivos</target>
+        </trans-unit>
+        <trans-unit id="WEBINTF_DOWNLOADFILES_LONG" translate="yes" xml:space="preserve">
+          <source>Just click the file you want to download from your Xbox.</source>
+          <target state="translated">Clique no arquivo que deseja baixar do seu Xbox.</target>
+        </trans-unit>
+        <trans-unit id="WEBINTF_DROPFILES" translate="yes" xml:space="preserve">
+          <source>Drop Files</source>
+          <target state="translated">Soltar Arquivos</target>
+        </trans-unit>
+        <trans-unit id="WEBINTF_DROPFILES_LONG" translate="yes" xml:space="preserve">
+          <source>Drop files in the window to add them to your Xbox.<it id="1" pos="open">&lt;br&gt;</it>Or click on the "+" button to use the file picker dialog.</source>
+          <target state="translated">Solte arquivos na janela para adicioná-los ao seu Xbox.<it id="1" pos="open">&lt;br&gt;</it>Ou clique no botão "+" para usar a janela de escolha de arquivos.</target>
+        </trans-unit>
+        <trans-unit id="WEBINTF_TITLE" translate="yes" xml:space="preserve">
+          <source>Sharing via WiFi</source>
+          <target state="translated">Compartilhando via WiFi</target>
+        </trans-unit>
+        <trans-unit id="CopyToLocalStorage" translate="yes" xml:space="preserve">
+          <source>copy to local storage</source>
+          <target state="translated">copiar para um armazenamento local</target>
+        </trans-unit>
+        <trans-unit id="ExternalStorageDeviceDetected" translate="yes" xml:space="preserve">
+          <source>VLC has detected an external storage device.</source>
+          <target state="translated">O VLC detectou um dispositivo de armazenamento externo.</target>
+        </trans-unit>
+        <trans-unit id="ReadFromExternalStorage" translate="yes" xml:space="preserve">
+          <source>Use external storage as media library.</source>
+          <target state="translated">Usa o armazenamento externo como biblioteca de mídias.</target>
+        </trans-unit>
+        <trans-unit id="SelectContentToCopy" translate="yes" xml:space="preserve">
+          <source>Copy media to the internal storage.</source>
+          <target state="translated">Copia a mídia para o armazenamento interno.</target>
+        </trans-unit>
+        <trans-unit id="WhatToDo" translate="yes" xml:space="preserve">
+          <source>What would you like to do?</source>
+          <target state="translated">O que gostaria de fazer?</target>
+        </trans-unit>
+        <trans-unit id="AskMe" translate="yes" xml:space="preserve">
+          <source>Ask me</source>
+          <target state="translated">Perguntar</target>
+        </trans-unit>
+        <trans-unit id="ExternalStorage" translate="yes" xml:space="preserve">
+          <source>external storage</source>
+          <target state="translated">armazenamento externo</target>
+        </trans-unit>
+        <trans-unit id="WhatToDoWhenExternalStorage" translate="yes" xml:space="preserve">
+          <source>What should VLC do when an external storage device has been detected?</source>
+          <target state="translated">O que o VLC deverá fazer quando um armazenamento externo for detectado?</target>
+        </trans-unit>
+        <trans-unit id="Cancel" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="translated">Cancelar</target>
+        </trans-unit>
+        <trans-unit id="DoNothing" translate="yes" xml:space="preserve">
+          <source>Do nothing</source>
+          <target state="translated">Não fazer nada</target>
+        </trans-unit>
+        <trans-unit id="Ok" translate="yes" xml:space="preserve">
+          <source>Ok</source>
+          <target state="translated">Ok</target>
+        </trans-unit>
+        <trans-unit id="Ignore" translate="yes" xml:space="preserve">
+          <source>Ignore</source>
+          <target state="translated">Ignorar</target>
+        </trans-unit>
+        <trans-unit id="Remember" translate="yes" xml:space="preserve">
+          <source>Remember</source>
+          <target state="translated">Salvar</target>
+        </trans-unit>
+        <trans-unit id="AddMediaHelp" translate="yes" xml:space="preserve">
+          <source>Please insert an external storage device</source>
+          <target state="translated">Por favor insira um dispositivo de armazenamento externo</target>
+        </trans-unit>
+        <trans-unit id="AddMediaHelpWithIP" translate="yes" xml:space="preserve">
+          <source>Please insert an external storage device, or go to http://{0}:8080 to upload some media</source>
+          <target state="translated">Por favor insira um dispositivo de armazenamento externo ou acesse http://{0}:8080 para enviar mídia</target>
+        </trans-unit>
+        <trans-unit id="CopyHelpDesktop" translate="yes" xml:space="preserve">
+          <source>Right-click on a file or a folder to copy it to the local storage.</source>
+          <target state="translated">Clique com o botão direito em um arquivo ou pasta para copiá-lo para um armazenamento local.</target>
+        </trans-unit>
+        <trans-unit id="CopyHelpMediaCenter" translate="yes" xml:space="preserve">
+          <source>Press "Y" on a file or a folder to copy it to the local storage.</source>
+          <target state="translated">Pressione "Y" em um arquivo ou pasta para copiá-lo para um armazenamento local.</target>
+        </trans-unit>
+        <trans-unit id="NoSubtitles" translate="yes" xml:space="preserve">
+          <source>No subtitle tracks</source>
+          <target state="translated">Sem trilhas de legenda</target>
+        </trans-unit>
+        <trans-unit id="ClearKeystore" translate="yes" xml:space="preserve">
+          <source>Clear saved credentials</source>
+          <target state="translated">Limpar credenciais salvas</target>
+        </trans-unit>
+        <trans-unit id="Credentials" translate="yes" xml:space="preserve">
+          <source>Credentials</source>
+          <target state="translated">Credenciais</target>
+        </trans-unit>
+        <trans-unit id="CopyHelpPhone" translate="yes" xml:space="preserve">
+          <source>Long press on a file or a folder to copy it to the local storage.</source>
+          <target state="translated">Pressione e segure em um arquivo ou pasta para copiá-lo para um armazenamento local.</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_FIT_SCREEN" translate="yes" xml:space="preserve">
+          <source>fit screen</source>
+          <target state="translated">ajustar à tela</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_FILL" translate="yes" xml:space="preserve">
+          <source>fill</source>
+          <target state="translated">preencher</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_16_9" translate="yes" xml:space="preserve">
+          <source>16:9</source>
+          <target state="translated">16:9</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_4_3" translate="yes" xml:space="preserve">
+          <source>4:3</source>
+          <target state="translated">4:3</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_2_35_1" translate="yes" xml:space="preserve">
+          <source>2.35:1</source>
+          <target state="translated">2,35:1</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_ORIGINAL" translate="yes" xml:space="preserve">
+          <source>original</source>
+          <target state="translated">original</target>
+        </trans-unit>
+        <trans-unit id="CompactOverlayPiP" translate="yes" xml:space="preserve">
+          <source>use windows 10 pip</source>
+          <target state="translated">usar o pip do windows 10</target>
+        </trans-unit>
+        <trans-unit id="TvUnsafeArea" translate="yes" xml:space="preserve">
+          <source>TV unsafe area</source>
+          <target state="translated">Área de TV insegura</target>
+        </trans-unit>
+        <trans-unit id="AddMarginExplanation" translate="yes" xml:space="preserve">
+          <source>Some TVs will not display the app correctly. To add some margin, turn this on</source>
+          <target state="translated">Algumas TV não exibirão o aplicativo corretamente. Para adicionar uma margem, habilite esta função</target>
+        </trans-unit>
+        <trans-unit id="ExtraMargin" translate="yes" xml:space="preserve">
+          <source>Extra margin</source>
+          <target state="translated">Margem extra</target>
+        </trans-unit>
+        <trans-unit id="NoExtraMargin" translate="yes" xml:space="preserve">
+          <source>No extra margin</source>
+          <target state="translated">Sem margem extra</target>
+        </trans-unit>
+        <trans-unit id="Restart" translate="yes" xml:space="preserve">
+          <source>restart</source>
+          <target state="translated">reiniciar</target>
+        </trans-unit>
+        <trans-unit id="Disconnect" translate="yes" xml:space="preserve">
+          <source>disconnect</source>
+          <target state="translated">disconectar</target>
+        </trans-unit>
+        <trans-unit id="XboxUpload" translate="yes" xml:space="preserve">
+          <source>Xbox upload</source>
+          <target state="translated">Envio ao Xbox</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/app/VLC.Universal/MultilingualResources/VLC.Universal.ro-RO.xlf
+++ b/app/VLC.Universal/MultilingualResources/VLC.Universal.ro-RO.xlf
@@ -1,0 +1,976 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file build-num="n/a" datatype="xml" original="VLC.UNIVERSAL/STRINGS/EN-US/RESOURCES.RESW" product-name="n/a" product-version="n/a" source-language="en-US" target-language="ro-RO" tool-id="MultilingualAppToolkit">
+    <header>
+      <tool tool-company="Microsoft" tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1605.0" />
+    </header>
+    <body>
+      <group datatype="resx" id="VLC.UNIVERSAL/STRINGS/EN-US/RESOURCES.RESW">
+        <trans-unit id="AboutTheApp" translate="yes" xml:space="preserve">
+          <source>about the app</source>
+          <target state="translated">despre aplicație</target>
+        </trans-unit>
+        <trans-unit id="Add" translate="yes" xml:space="preserve">
+          <source>add</source>
+          <target state="translated">adăugați</target>
+        </trans-unit>
+        <trans-unit id="AddFolder" translate="yes" xml:space="preserve">
+          <source>add folder</source>
+          <target state="translated">adăugați director</target>
+        </trans-unit>
+        <trans-unit id="AddToCollection" translate="yes" xml:space="preserve">
+          <source>add to collection</source>
+          <target state="translated">adăugați la colecție</target>
+        </trans-unit>
+        <trans-unit id="AddToCurrentPlaylist" translate="yes" xml:space="preserve">
+          <source>add to current playlist</source>
+          <target state="translated">adăugați la lista curentă de redare</target>
+        </trans-unit>
+        <trans-unit id="AddToPlaylist" translate="yes" xml:space="preserve">
+          <source>add to playlist</source>
+          <target state="translated">adăugați la lista de redare</target>
+        </trans-unit>
+        <trans-unit id="Albums" translate="yes" xml:space="preserve">
+          <source>albums</source>
+          <target state="translated">albume</target>
+        </trans-unit>
+        <trans-unit id="AlbumsFound" translate="yes" xml:space="preserve">
+          <source>albums found : {0}</source>
+          <target state="translated">albume găsite : {0}</target>
+        </trans-unit>
+        <trans-unit id="Animations" translate="yes" xml:space="preserve">
+          <source>animations</source>
+          <target state="translated">animații</target>
+        </trans-unit>
+        <trans-unit id="AppTheme" translate="yes" xml:space="preserve">
+          <source>application theme</source>
+          <target state="translated">tema aplicației</target>
+        </trans-unit>
+        <trans-unit id="Artists" translate="yes" xml:space="preserve">
+          <source>artists</source>
+          <target state="translated">artiști</target>
+        </trans-unit>
+        <trans-unit id="Audio" translate="yes" xml:space="preserve">
+          <source>audio</source>
+          <target state="translated">audio</target>
+        </trans-unit>
+        <trans-unit id="AudioDelay" translate="yes" xml:space="preserve">
+          <source>audio delay</source>
+          <target state="translated">întârziere audio</target>
+        </trans-unit>
+        <trans-unit id="AudioTracks" translate="yes" xml:space="preserve">
+          <source>Audio Tracks</source>
+          <target state="translated">Piese audio</target>
+        </trans-unit>
+        <trans-unit id="Back" translate="yes" xml:space="preserve">
+          <source>back</source>
+          <target state="translated">înapoi</target>
+        </trans-unit>
+        <trans-unit id="CameraRoll" translate="yes" xml:space="preserve">
+          <source>camera roll</source>
+          <target state="translated">Fotografii</target>
+        </trans-unit>
+        <trans-unit id="ChangeAlbumCover" translate="yes" xml:space="preserve">
+          <source>change album cover</source>
+          <target state="translated">modificați coperta albumului</target>
+        </trans-unit>
+        <trans-unit id="Chapters" translate="yes" xml:space="preserve">
+          <source>Chapters</source>
+          <target state="translated">Capitole</target>
+        </trans-unit>
+        <trans-unit id="CheckCredentials" translate="yes" xml:space="preserve">
+          <source>an error occured, please check your credentials</source>
+          <target state="translated">a apărut o eroare, vă rugăm verificați-vă acreditările</target>
+        </trans-unit>
+        <trans-unit id="Connect" translate="yes" xml:space="preserve">
+          <source>connect</source>
+          <target state="translated">conectare</target>
+        </trans-unit>
+        <trans-unit id="ConnectedToLastFM" translate="yes" xml:space="preserve">
+          <source>connected to Last.FM</source>
+          <target state="translated">conectat la Last.FM</target>
+        </trans-unit>
+        <trans-unit id="Connecting" translate="yes" xml:space="preserve">
+          <source>connecting</source>
+          <target state="translated">se conectează</target>
+        </trans-unit>
+        <trans-unit id="ConnectToLastFM" translate="yes" xml:space="preserve">
+          <source>connect to Last.FM</source>
+          <target state="translated">se conectează la Last.FM</target>
+        </trans-unit>
+        <trans-unit id="CrashReport" translate="yes" xml:space="preserve">
+          <source>crash report</source>
+          <target state="translated">raport de accident</target>
+        </trans-unit>
+        <trans-unit id="DecreaseSpeed" translate="yes" xml:space="preserve">
+          <source>decrease speed</source>
+          <target state="translated">descrește viteza</target>
+        </trans-unit>
+        <trans-unit id="DecreaseVolume" translate="yes" xml:space="preserve">
+          <source>decrease volume</source>
+          <target state="translated">descrește volumul</target>
+        </trans-unit>
+        <trans-unit id="DeletePlaylist" translate="yes" xml:space="preserve">
+          <source>delete playlist</source>
+          <target state="translated">ștergeți lista de redare</target>
+        </trans-unit>
+        <trans-unit id="DeleteSelected" translate="yes" xml:space="preserve">
+          <source>delete selected</source>
+          <target state="translated">ștergeți elementele selectate</target>
+        </trans-unit>
+        <trans-unit id="EditMetadata" translate="yes" xml:space="preserve">
+          <source>edit metadata</source>
+          <target state="translated">editați metadata</target>
+        </trans-unit>
+        <trans-unit id="ElementsNotFound" translate="yes" xml:space="preserve">
+          <source>we did not find elements in there</source>
+          <target state="translated">nu am găsit elemente acolo</target>
+        </trans-unit>
+        <trans-unit id="EnterURL" translate="yes" xml:space="preserve">
+          <source>enter a url</source>
+          <target state="translated">introduceți o adresă URL</target>
+        </trans-unit>
+        <trans-unit id="Episode" translate="yes" xml:space="preserve">
+          <source>episode</source>
+          <target state="translated">episod</target>
+        </trans-unit>
+        <trans-unit id="EvenIfBackground" translate="yes" xml:space="preserve">
+          <source>even if the app is in background</source>
+          <target state="translated">chiar dacă aplicația rulează în fundal</target>
+        </trans-unit>
+        <trans-unit id="EvenIfNotBackground" translate="yes" xml:space="preserve">
+          <source>even if the app is not in background</source>
+          <target state="translated">chiar dacă aplicația nu rulează în fundal</target>
+        </trans-unit>
+        <trans-unit id="FailFilePlayBackground" translate="yes" xml:space="preserve">
+          <source>This file may not play in the background</source>
+          <target state="translated">Este posibil ca acest fișier să nu poată fi redat  în fundal</target>
+        </trans-unit>
+        <trans-unit id="FailNavigateVideoPlayerPage" translate="yes" xml:space="preserve">
+          <source>VLC failed to navigate to the Video Player page</source>
+          <target state="translated">VLC nu a reușit să navigheze la pagina Video Player</target>
+        </trans-unit>
+        <trans-unit id="FailOpenVideo" translate="yes" xml:space="preserve">
+          <source>VLC failed to open the video</source>
+          <target state="translated">VLC nu a reușit să deschidă videoclipul</target>
+        </trans-unit>
+        <trans-unit id="FailStartVLCEngine" translate="yes" xml:space="preserve">
+          <source>The app failed to start the VLC engine</source>
+          <target state="translated">Aplicația nu a reușit să pornească motorul VLC</target>
+        </trans-unit>
+        <trans-unit id="FeedbackThankYou" translate="yes" xml:space="preserve">
+          <source>feedback sent! thank you</source>
+          <target state="translated">feedback trimis! mulțumim</target>
+        </trans-unit>
+        <trans-unit id="FileExplorer" translate="yes" xml:space="preserve">
+          <source>browse</source>
+          <target state="translated">navigare</target>
+        </trans-unit>
+        <trans-unit id="HardwareDecoding" translate="yes" xml:space="preserve">
+          <source>hardware decoding</source>
+          <target state="translated">decodificare hardware</target>
+        </trans-unit>
+        <trans-unit id="HardwareDecodingDescription" translate="yes" xml:space="preserve">
+          <source>Hardware decoding may not work on your device.</source>
+          <target state="translated">Este posibil ca decodarea hardware să nu funcționeze pe dispozitiv.</target>
+        </trans-unit>
+        <trans-unit id="HaveToSelectPlaylist" translate="yes" xml:space="preserve">
+          <source>please select a playlist</source>
+          <target state="translated">vă rugăm selectați o listă de redare</target>
+        </trans-unit>
+        <trans-unit id="Home" translate="yes" xml:space="preserve">
+          <source>home</source>
+          <target state="translated">home</target>
+        </trans-unit>
+        <trans-unit id="HomePage" translate="yes" xml:space="preserve">
+          <source>home page</source>
+          <target state="translated">pagina home</target>
+        </trans-unit>
+        <trans-unit id="HomePageDescription" translate="yes" xml:space="preserve">
+          <source>VLC will start on the selected page</source>
+          <target state="translated">VLC va porni pe pagina selectată</target>
+        </trans-unit>
+        <trans-unit id="HoweverYouMayFindWhatYouWantHere" translate="yes" xml:space="preserve">
+          <source>however you may find what you're looking for here</source>
+          <target state="translated">cu toate acestea, puteți găsi aici ceea ce căutați </target>
+        </trans-unit>
+        <trans-unit id="HowToFavoriteAlbum1" translate="yes" xml:space="preserve">
+          <source>to favorite an album, just press</source>
+          <target state="translated">pentru a adăuga un album la lista de favorite, apăsați</target>
+        </trans-unit>
+        <trans-unit id="HowToFavoriteAlbum2" translate="yes" xml:space="preserve">
+          <source>and you'll get an instant access to it</source>
+          <target state="translated">și veți avea acces imediat la el</target>
+        </trans-unit>
+        <trans-unit id="ImportantSponsors" translate="yes" xml:space="preserve">
+          <source>important sponsors</source>
+          <target state="translated">sponsori importanți</target>
+        </trans-unit>
+        <trans-unit id="IncreaseSpeed" translate="yes" xml:space="preserve">
+          <source>increase speed</source>
+          <target state="translated">mărește viteza</target>
+        </trans-unit>
+        <trans-unit id="IncreaseVolume" translate="yes" xml:space="preserve">
+          <source>increase volume</source>
+          <target state="translated">crește volumul</target>
+        </trans-unit>
+        <trans-unit id="ItsEmpty" translate="yes" xml:space="preserve">
+          <source>it's empty here</source>
+          <target state="translated">nu este nimic aici</target>
+        </trans-unit>
+        <trans-unit id="KeyboardShortcuts" translate="yes" xml:space="preserve">
+          <source>keyboard shortcuts</source>
+          <target state="translated">comenzi rapide de la tastatură</target>
+        </trans-unit>
+        <trans-unit id="License" translate="yes" xml:space="preserve">
+          <source>license</source>
+          <target state="translated">licență</target>
+        </trans-unit>
+        <trans-unit id="Loading" translate="yes" xml:space="preserve">
+          <source>loading</source>
+          <target state="translated">încărcare</target>
+        </trans-unit>
+        <trans-unit id="LoadingMusic" translate="yes" xml:space="preserve">
+          <source>loading music</source>
+          <target state="translated">încărcare audio</target>
+        </trans-unit>
+        <trans-unit id="MostPlayedArtists" translate="yes" xml:space="preserve">
+          <source>most played artists</source>
+          <target state="translated">cei mai mulți artiști ascultați</target>
+        </trans-unit>
+        <trans-unit id="Music" translate="yes" xml:space="preserve">
+          <source>music</source>
+          <target state="translated">muzică</target>
+        </trans-unit>
+        <trans-unit id="MusicFolders" translate="yes" xml:space="preserve">
+          <source>music folders</source>
+          <target state="translated">dosare de muzică</target>
+        </trans-unit>
+        <trans-unit id="MusicFoldersDescription" translate="yes" xml:space="preserve">
+          <source>VLC will only search songs that are in your music library. You can add folders to your library here</source>
+          <target state="translated">VLC va căuta doar melodii care se află în biblioteca muzicală. Puteți adăuga foldere în biblioteca dvs. aici</target>
+        </trans-unit>
+        <trans-unit id="MusicSettings" translate="yes" xml:space="preserve">
+          <source>Music Settings</source>
+          <target state="translated">Setări audio</target>
+        </trans-unit>
+        <trans-unit id="MusicShows" translate="yes" xml:space="preserve">
+          <source>music shows</source>
+          <target state="translated">spectacole muzicale</target>
+        </trans-unit>
+        <trans-unit id="Mute" translate="yes" xml:space="preserve">
+          <source>mute</source>
+          <target state="translated">mut</target>
+        </trans-unit>
+        <trans-unit id="MyPlaylists" translate="yes" xml:space="preserve">
+          <source>my playlists</source>
+          <target state="translated">listele mele de redare</target>
+        </trans-unit>
+        <trans-unit id="Network" translate="yes" xml:space="preserve">
+          <source>network</source>
+          <target state="translated">rețea</target>
+        </trans-unit>
+        <trans-unit id="NewPlaylist" translate="yes" xml:space="preserve">
+          <source>new playlist</source>
+          <target state="translated">listă nouă de redare</target>
+        </trans-unit>
+        <trans-unit id="NewVideos" translate="yes" xml:space="preserve">
+          <source>new videos</source>
+          <target state="translated">videoclipuri noi</target>
+        </trans-unit>
+        <trans-unit id="No" translate="yes" xml:space="preserve">
+          <source>no</source>
+          <target state="translated">nu</target>
+        </trans-unit>
+        <trans-unit id="NoBiographyFound" translate="yes" xml:space="preserve">
+          <source>no bio found for this artist</source>
+          <target state="translated">nu am găsit nicio biografie pentru acest artist</target>
+        </trans-unit>
+        <trans-unit id="NoCameraVideosFound" translate="yes" xml:space="preserve">
+          <source>no camera videos found</source>
+          <target state="translated">nu am găsit camere video</target>
+        </trans-unit>
+        <trans-unit id="NoFavoriteAlbums" translate="yes" xml:space="preserve">
+          <source>no favorite albums</source>
+          <target state="translated">niciun album favorit</target>
+        </trans-unit>
+        <trans-unit id="NoInternetConnection" translate="yes" xml:space="preserve">
+          <source>no internet connection</source>
+          <target state="translated">nicio conexiune la internet</target>
+        </trans-unit>
+        <trans-unit id="NoPlaylists" translate="yes" xml:space="preserve">
+          <source>no playlists</source>
+          <target state="translated">nicio listă de redare</target>
+        </trans-unit>
+        <trans-unit id="NoShowsFound" translate="yes" xml:space="preserve">
+          <source>no shows found</source>
+          <target state="translated">nu a fost găsit niciun spectacol</target>
+        </trans-unit>
+        <trans-unit id="NothingToSeeHere" translate="yes" xml:space="preserve">
+          <source>there's nothing to see here</source>
+          <target state="translated">nu este nimic de văzut aici</target>
+        </trans-unit>
+        <trans-unit id="Notifications" translate="yes" xml:space="preserve">
+          <source>notifications</source>
+          <target state="translated">notificări</target>
+        </trans-unit>
+        <trans-unit id="NotificationWhenSongStarts" translate="yes" xml:space="preserve">
+          <source>when the song starts</source>
+          <target state="translated">când începe melodia</target>
+        </trans-unit>
+        <trans-unit id="NoVideosFound" translate="yes" xml:space="preserve">
+          <source>we did not find video</source>
+          <target state="translated">nu am găsit fișiere video</target>
+        </trans-unit>
+        <trans-unit id="NowPlaying" translate="yes" xml:space="preserve">
+          <source>now playing</source>
+          <target state="translated">redare în prezent</target>
+        </trans-unit>
+        <trans-unit id="OpenFile" translate="yes" xml:space="preserve">
+          <source>open file</source>
+          <target state="translated">deschide fișier</target>
+        </trans-unit>
+        <trans-unit id="OpenStream" translate="yes" xml:space="preserve">
+          <source>open stream</source>
+          <target state="translated">deschideți un flux de rețea</target>
+        </trans-unit>
+        <trans-unit id="OpenSubtitle" translate="yes" xml:space="preserve">
+          <source>open subtitle</source>
+          <target state="translated">deschide subtitrare</target>
+        </trans-unit>
+        <trans-unit id="OrderAscending" translate="yes" xml:space="preserve">
+          <source>ascending</source>
+          <target state="translated">în ordine crescătoare</target>
+        </trans-unit>
+        <trans-unit id="OrderByAlbum" translate="yes" xml:space="preserve">
+          <source>by album</source>
+          <target state="translated">după album</target>
+        </trans-unit>
+        <trans-unit id="OrderByArtist" translate="yes" xml:space="preserve">
+          <source>by artist</source>
+          <target state="translated">după artist</target>
+        </trans-unit>
+        <trans-unit id="OrderByDate" translate="yes" xml:space="preserve">
+          <source>by date</source>
+          <target state="translated">după dată</target>
+        </trans-unit>
+        <trans-unit id="OrderDescending" translate="yes" xml:space="preserve">
+          <source>descending</source>
+          <target state="translated">în ordine descrescătoare</target>
+        </trans-unit>
+        <trans-unit id="Password" translate="yes" xml:space="preserve">
+          <source>password</source>
+          <target state="translated">parolă</target>
+        </trans-unit>
+        <trans-unit id="Pause" translate="yes" xml:space="preserve">
+          <source>pause</source>
+          <target state="translated">pauză</target>
+        </trans-unit>
+        <trans-unit id="PinAlbum" translate="yes" xml:space="preserve">
+          <source>pin album</source>
+          <target state="translated">fixare album</target>
+        </trans-unit>
+        <trans-unit id="PinArtist" translate="yes" xml:space="preserve">
+          <source>pin artist</source>
+          <target state="translated">fixare artist</target>
+        </trans-unit>
+        <trans-unit id="Play" translate="yes" xml:space="preserve">
+          <source>play</source>
+          <target state="translated">redare</target>
+        </trans-unit>
+        <trans-unit id="PlayAlbum" translate="yes" xml:space="preserve">
+          <source>play album</source>
+          <target state="translated">redare album</target>
+        </trans-unit>
+        <trans-unit id="PlayAll" translate="yes" xml:space="preserve">
+          <source>play all</source>
+          <target state="translated">redare toate</target>
+        </trans-unit>
+        <trans-unit id="Playback" translate="yes" xml:space="preserve">
+          <source>playback</source>
+          <target state="translated">redare</target>
+        </trans-unit>
+        <trans-unit id="PlayerSettings" translate="yes" xml:space="preserve">
+          <source>Player Settings</source>
+          <target state="translated">Setări de redare</target>
+        </trans-unit>
+        <trans-unit id="PlayFolder" translate="yes" xml:space="preserve">
+          <source>play folder</source>
+          <target state="translated">redare dosar</target>
+        </trans-unit>
+        <trans-unit id="Playlist" translate="yes" xml:space="preserve">
+          <source>playlist</source>
+          <target state="translated">listă de redare</target>
+        </trans-unit>
+        <trans-unit id="PlaylistAlreadyExists" translate="yes" xml:space="preserve">
+          <source>this playlist already exists</source>
+          <target state="translated">această listă de redare există deja</target>
+        </trans-unit>
+        <trans-unit id="PlaylistNamePlaceholder" translate="yes" xml:space="preserve">
+          <source>playlist name</source>
+          <target state="translated">nume listă de redare</target>
+        </trans-unit>
+        <trans-unit id="Playlists" translate="yes" xml:space="preserve">
+          <source>playlists</source>
+          <target state="translated">liste de redare</target>
+        </trans-unit>
+        <trans-unit id="PlayTrack" translate="yes" xml:space="preserve">
+          <source>play track</source>
+          <target state="translated">redare pistă</target>
+        </trans-unit>
+        <trans-unit id="PlayVideo" translate="yes" xml:space="preserve">
+          <source>play video</source>
+          <target state="translated">redare video</target>
+        </trans-unit>
+        <trans-unit id="PrivacyStatement" translate="yes" xml:space="preserve">
+          <source>privacy statement</source>
+          <target state="translated">declarație de confidențialitate</target>
+        </trans-unit>
+        <trans-unit id="Favorites" translate="yes" xml:space="preserve">
+          <source>Favorites</source>
+          <target state="translated">Favorite</target>
+        </trans-unit>
+        <trans-unit id="RefreshMusicLibrary" translate="yes" xml:space="preserve">
+          <source>refresh music library</source>
+          <target state="translated">actualizați biblioteca muzicală</target>
+        </trans-unit>
+        <trans-unit id="RefreshVideoLibrary" translate="yes" xml:space="preserve">
+          <source>refresh video library</source>
+          <target state="translated">actualizați biblioteca video</target>
+        </trans-unit>
+        <trans-unit id="RemovableStorage" translate="yes" xml:space="preserve">
+          <source>removable storage</source>
+          <target state="translated">stocare amovibilă</target>
+        </trans-unit>
+        <trans-unit id="RemoveFolder" translate="yes" xml:space="preserve">
+          <source>remove folder</source>
+          <target state="translated">ștergere dosar</target>
+        </trans-unit>
+        <trans-unit id="RemoveMusicFolderDescription" translate="yes" xml:space="preserve">
+          <source>If you don't want this folder in your Music library, you can remove it. It will affect all apps, not only VLC</source>
+          <target state="translated">Dacă nu doriți acest director în biblioteca dvs. muzicală, îl puteți elimina. Această acțiune va afecta toate aplicațiile, nu numai VLC</target>
+        </trans-unit>
+        <trans-unit id="RemoveVideoFolderDescription" translate="yes" xml:space="preserve">
+          <source>If you don't want this folder in your Video library, you can remove it. It will affect all apps, not only VLC</source>
+          <target state="translated">Dacă nu doriți acest director în biblioteca dvs. video, îl puteți elimina. Această acțiune va afecta toate aplicațiile, nu numai VLC</target>
+        </trans-unit>
+        <trans-unit id="Reset" translate="yes" xml:space="preserve">
+          <source>reset</source>
+          <target state="translated">restabilire</target>
+        </trans-unit>
+        <trans-unit id="ResetMusicDatabase" translate="yes" xml:space="preserve">
+          <source>reset music database</source>
+          <target state="translated">resetare baza de date cu fișiere audio</target>
+        </trans-unit>
+        <trans-unit id="ResetSpeed" translate="yes" xml:space="preserve">
+          <source>reset speed</source>
+          <target state="translated">restabilire viteză</target>
+        </trans-unit>
+        <trans-unit id="RichAnimationsDescription" translate="yes" xml:space="preserve">
+          <source>Use rich animations in the slideshows</source>
+          <target state="translated">Folosire animații bogate în prezentări</target>
+        </trans-unit>
+        <trans-unit id="Search" translate="yes" xml:space="preserve">
+          <source>search</source>
+          <target state="translated">căutare</target>
+        </trans-unit>
+        <trans-unit id="Season" translate="yes" xml:space="preserve">
+          <source>season</source>
+          <target state="translated">sezon</target>
+        </trans-unit>
+        <trans-unit id="Settings" translate="yes" xml:space="preserve">
+          <source>settings</source>
+          <target state="translated">setări</target>
+        </trans-unit>
+        <trans-unit id="ShowPlaylist" translate="yes" xml:space="preserve">
+          <source>show playlist</source>
+          <target state="translated">afișare listă de redare</target>
+        </trans-unit>
+        <trans-unit id="Shows" translate="yes" xml:space="preserve">
+          <source>shows</source>
+          <target state="translated">spectacole muzicale</target>
+        </trans-unit>
+        <trans-unit id="Shuffle" translate="yes" xml:space="preserve">
+          <source>shuffle</source>
+          <target state="translated">amestecare</target>
+        </trans-unit>
+        <trans-unit id="Songs" translate="yes" xml:space="preserve">
+          <source>songs</source>
+          <target state="translated">cântece</target>
+        </trans-unit>
+        <trans-unit id="SpecialThanks" translate="yes" xml:space="preserve">
+          <source>special thanks</source>
+          <target state="translated">mulțumiri speciale</target>
+        </trans-unit>
+        <trans-unit id="Speed" translate="yes" xml:space="preserve">
+          <source>speed</source>
+          <target state="translated">viteză</target>
+        </trans-unit>
+        <trans-unit id="Stop" translate="yes" xml:space="preserve">
+          <source>stop</source>
+          <target state="translated">stop</target>
+        </trans-unit>
+        <trans-unit id="SubtitleDelay" translate="yes" xml:space="preserve">
+          <source>subtitle delay</source>
+          <target state="translated">întârziere subtitrare</target>
+        </trans-unit>
+        <trans-unit id="Subtitles" translate="yes" xml:space="preserve">
+          <source>Subtitles</source>
+          <target state="translated">Subtitrări</target>
+        </trans-unit>
+        <trans-unit id="SubtitlesEncoding" translate="yes" xml:space="preserve">
+          <source>subtitles encoding</source>
+          <target state="translated">codarea subtitrărilor</target>
+        </trans-unit>
+        <trans-unit id="Theme" translate="yes" xml:space="preserve">
+          <source>theme</source>
+          <target state="translated">temă</target>
+        </trans-unit>
+        <trans-unit id="TileRemoved" translate="yes" xml:space="preserve">
+          <source>tile removed</source>
+          <target state="translated">șablon șters</target>
+        </trans-unit>
+        <trans-unit id="TopVideos" translate="yes" xml:space="preserve">
+          <source>top videos</source>
+          <target state="translated">cele mai populare videoclipuri</target>
+        </trans-unit>
+        <trans-unit id="TrackAddedToYourPlaylist" translate="yes" xml:space="preserve">
+          <source>track added to the playlist</source>
+          <target state="translated">piesă adăugată în lista de redare</target>
+        </trans-unit>
+        <trans-unit id="TrackAlreadyExistsInPlaylist" translate="yes" xml:space="preserve">
+          <source>this track is already in that playlist</source>
+          <target state="translated">piesa de află deja în lista de redare</target>
+        </trans-unit>
+        <trans-unit id="Tracks" translate="yes" xml:space="preserve">
+          <source>tracks</source>
+          <target state="translated">Piese</target>
+        </trans-unit>
+        <trans-unit id="UnknownAlbum" translate="yes" xml:space="preserve">
+          <source>Unknown album</source>
+          <target state="translated">Album necunoscut</target>
+        </trans-unit>
+        <trans-unit id="UnknownArtist" translate="yes" xml:space="preserve">
+          <source>Unknown artist</source>
+          <target state="translated">Artist necunoscut</target>
+        </trans-unit>
+        <trans-unit id="UnknownShow" translate="yes" xml:space="preserve">
+          <source>Unknown show</source>
+          <target state="translated">Spectacol necunoscut</target>
+        </trans-unit>
+        <trans-unit id="UnknownTrack" translate="yes" xml:space="preserve">
+          <source>Unknown track</source>
+          <target state="translated">Piesă necunoscută</target>
+        </trans-unit>
+        <trans-unit id="UserInterface" translate="yes" xml:space="preserve">
+          <source>User Interface</source>
+          <target state="translated">Interfața cu utilizatorul</target>
+        </trans-unit>
+        <trans-unit id="Username" translate="yes" xml:space="preserve">
+          <source>username</source>
+          <target state="translated">nume utilizator</target>
+        </trans-unit>
+        <trans-unit id="Video" translate="yes" xml:space="preserve">
+          <source>video</source>
+          <target state="translated">video</target>
+        </trans-unit>
+        <trans-unit id="VideoFolders" translate="yes" xml:space="preserve">
+          <source>video folders</source>
+          <target state="translated">foldere video</target>
+        </trans-unit>
+        <trans-unit id="VideoFoldersDescription" translate="yes" xml:space="preserve">
+          <source>VLC will only search videos that are in your video library. You can add folders to your library here</source>
+          <target state="translated">VLC va căuta numai videoclipuri care se află în biblioteca dvs. video. Puteți adăuga foldere în biblioteca dvs. aici</target>
+        </trans-unit>
+        <trans-unit id="VideoPlayback" translate="yes" xml:space="preserve">
+          <source>video playback</source>
+          <target state="translated">redare video</target>
+        </trans-unit>
+        <trans-unit id="VideoPlaybackInBackground" translate="yes" xml:space="preserve">
+          <source>play video in background</source>
+          <target state="translated">redare video în fundal</target>
+        </trans-unit>
+        <trans-unit id="Videos" translate="yes" xml:space="preserve">
+          <source>videos</source>
+          <target state="translated">fișiere video</target>
+        </trans-unit>
+        <trans-unit id="VideoSettings" translate="yes" xml:space="preserve">
+          <source>Video Settings</source>
+          <target state="translated">Setări video</target>
+        </trans-unit>
+        <trans-unit id="ViewAlbum" translate="yes" xml:space="preserve">
+          <source>view album</source>
+          <target state="translated">vizualizați albumul</target>
+        </trans-unit>
+        <trans-unit id="ViewArtist" translate="yes" xml:space="preserve">
+          <source>view artist</source>
+          <target state="translated">vizualizați artistul</target>
+        </trans-unit>
+        <trans-unit id="Volume" translate="yes" xml:space="preserve">
+          <source>volume</source>
+          <target state="translated">volum</target>
+        </trans-unit>
+        <trans-unit id="WeNeedYourHelp" translate="yes" xml:space="preserve">
+          <source>we need your help</source>
+          <target state="translated">avem nevoie de ajutorul dvs.</target>
+        </trans-unit>
+        <trans-unit id="Yes" translate="yes" xml:space="preserve">
+          <source>yes</source>
+          <target state="translated">da</target>
+        </trans-unit>
+        <trans-unit id="YourMusic" translate="yes" xml:space="preserve">
+          <source>your music</source>
+          <target state="translated">muzica dvs.</target>
+        </trans-unit>
+        <trans-unit id="AccentColor" translate="yes" xml:space="preserve">
+          <source>accent color</source>
+          <target state="translated">tonalitate culoare</target>
+        </trans-unit>
+        <trans-unit id="BackgroundColor" translate="yes" xml:space="preserve">
+          <source>background color</source>
+          <target state="translated">culoare de fundal</target>
+        </trans-unit>
+        <trans-unit id="Dark" translate="yes" xml:space="preserve">
+          <source>dark</source>
+          <target state="translated">întunecat</target>
+        </trans-unit>
+        <trans-unit id="Light" translate="yes" xml:space="preserve">
+          <source>light</source>
+          <target state="translated">lumină</target>
+        </trans-unit>
+        <trans-unit id="TitleBar" translate="yes" xml:space="preserve">
+          <source>title bar</source>
+          <target state="translated">bara de titlu</target>
+        </trans-unit>
+        <trans-unit id="NeedRestart" translate="yes" xml:space="preserve">
+          <source>You need to restart the app to apply changes</source>
+          <target state="translated">Trebuie să reporniți aplicația pentru a aplica modificările</target>
+        </trans-unit>
+        <trans-unit id="Zoom" translate="yes" xml:space="preserve">
+          <source>zoom</source>
+          <target state="translated">redimensionare</target>
+        </trans-unit>
+        <trans-unit id="AreYouSure" translate="yes" xml:space="preserve">
+          <source>are you sure?</source>
+          <target state="translated">sunteți sigur?</target>
+        </trans-unit>
+        <trans-unit id="MediaCantBeRead" translate="yes" xml:space="preserve">
+          <source>the media can't be read</source>
+          <target state="translated">fișierul media nu poate fi citit</target>
+        </trans-unit>
+        <trans-unit id="Sorry" translate="yes" xml:space="preserve">
+          <source>we're sorry</source>
+          <target state="translated">ne pare rău</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_BEST_FIT" translate="yes" xml:space="preserve">
+          <source>best fit</source>
+          <target state="translated">cel mai potrivit</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_FIT_HORIZONTAL" translate="yes" xml:space="preserve">
+          <source>horizontal cropping</source>
+          <target state="translated">decupare pe orizontală</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_FIT_VERTICAL" translate="yes" xml:space="preserve">
+          <source>vertical cropping</source>
+          <target state="translated">decupare pe verticală</target>
+        </trans-unit>
+        <trans-unit id="YourPlaylistWontBeAccessible" translate="yes" xml:space="preserve">
+          <source>your playlist won't be accessible</source>
+          <target state="translated">lista dvs. de redare nu va fi accesibilă</target>
+        </trans-unit>
+        <trans-unit id="NoArtistShowsFound" translate="yes" xml:space="preserve">
+          <source>we didn't find shows for this artist</source>
+          <target state="translated">nu am găsit spectacole pentru acest artist</target>
+        </trans-unit>
+        <trans-unit id="NoResults" translate="yes" xml:space="preserve">
+          <source>no results</source>
+          <target state="translated">niciun rezultat</target>
+        </trans-unit>
+        <trans-unit id="ForceLandscape" translate="yes" xml:space="preserve">
+          <source>Force landscape</source>
+          <target state="translated">Forțează afișarea pe lat</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_STRETCH" translate="yes" xml:space="preserve">
+          <source>stretch</source>
+          <target state="translated">întindere</target>
+        </trans-unit>
+        <trans-unit id="SimilarArtists" translate="yes" xml:space="preserve">
+          <source>Similar artists</source>
+          <target state="translated">Artiști similari</target>
+        </trans-unit>
+        <trans-unit id="EnglishLanguage" translate="yes" xml:space="preserve">
+          <source>English</source>
+          <target state="translated">Engleză</target>
+        </trans-unit>
+        <trans-unit id="FrenchLanguage" translate="yes" xml:space="preserve">
+          <source>French</source>
+          <target state="translated">Franceză</target>
+        </trans-unit>
+        <trans-unit id="JapaneseLanguage" translate="yes" xml:space="preserve">
+          <source>Japanese</source>
+          <target state="translated">Japoneză</target>
+        </trans-unit>
+        <trans-unit id="GermanLanguage" translate="yes" xml:space="preserve">
+          <source>German</source>
+          <target state="translated">Germană</target>
+        </trans-unit>
+        <trans-unit id="PolishLanguage" translate="yes" xml:space="preserve">
+          <source>Polish</source>
+          <target state="translated">Poloneză</target>
+        </trans-unit>
+        <trans-unit id="SlovakLanguage" translate="yes" xml:space="preserve">
+          <source>Slovak</source>
+          <target state="translated">Slovacă</target>
+        </trans-unit>
+        <trans-unit id="DanishLanguage" translate="yes" xml:space="preserve">
+          <source>Danish</source>
+          <target state="translated">Daneză</target>
+        </trans-unit>
+        <trans-unit id="SpanishLanguage" translate="yes" xml:space="preserve">
+          <source>Spanish</source>
+          <target state="translated">Spaniolă</target>
+        </trans-unit>
+        <trans-unit id="HungarianLanguage" translate="yes" xml:space="preserve">
+          <source>Hungarian</source>
+          <target state="translated">Maghiară</target>
+        </trans-unit>
+        <trans-unit id="ItalianLanguage" translate="yes" xml:space="preserve">
+          <source>Italian</source>
+          <target state="translated">Italiană</target>
+        </trans-unit>
+        <trans-unit id="KoreanLanguage" translate="yes" xml:space="preserve">
+          <source>Korean</source>
+          <target state="translated">Coreeană</target>
+        </trans-unit>
+        <trans-unit id="MalayLanguage" translate="yes" xml:space="preserve">
+          <source>Malay</source>
+          <target state="translated">Malaeziană</target>
+        </trans-unit>
+        <trans-unit id="NorwegianLanguage" translate="yes" xml:space="preserve">
+          <source>Norwegian</source>
+          <target state="translated">Norvegiană</target>
+        </trans-unit>
+        <trans-unit id="DutchLanguage" translate="yes" xml:space="preserve">
+          <source>Dutch</source>
+          <target state="translated">Olandeză</target>
+        </trans-unit>
+        <trans-unit id="RussianLanguage" translate="yes" xml:space="preserve">
+          <source>Russian</source>
+          <target state="translated">Rusă</target>
+        </trans-unit>
+        <trans-unit id="SwedishLanguage" translate="yes" xml:space="preserve">
+          <source>Swedish</source>
+          <target state="translated">Suedeză</target>
+        </trans-unit>
+        <trans-unit id="TurkishLanguage" translate="yes" xml:space="preserve">
+          <source>Turkish</source>
+          <target state="translated">Turcă</target>
+        </trans-unit>
+        <trans-unit id="UkrainianLanguage" translate="yes" xml:space="preserve">
+          <source>Ukrainian</source>
+          <target state="translated">Ucraineană</target>
+        </trans-unit>
+        <trans-unit id="ChineseLanguage" translate="yes" xml:space="preserve">
+          <source>Chinese</source>
+          <target state="translated">Chineză</target>
+        </trans-unit>
+        <trans-unit id="PortugueseLanguage" translate="yes" xml:space="preserve">
+          <source>Portuguese</source>
+          <target state="translated">Portugheză</target>
+        </trans-unit>
+        <trans-unit id="CzechLanguage" translate="yes" xml:space="preserve">
+          <source>Czech</source>
+          <target state="translated">Cehă</target>
+        </trans-unit>
+        <trans-unit id="IcelandicLanguage" translate="yes" xml:space="preserve">
+          <source>Icelandic</source>
+          <target state="translated">Islandeză</target>
+        </trans-unit>
+        <trans-unit id="HebrewLanguage" translate="yes" xml:space="preserve">
+          <source>Hebrew</source>
+          <target state="translated">Ebraică</target>
+        </trans-unit>
+        <trans-unit id="Languages" translate="yes" xml:space="preserve">
+          <source>Languages</source>
+          <target state="translated">Limbi</target>
+        </trans-unit>
+        <trans-unit id="SelectLanguageDescription" translate="yes" xml:space="preserve">
+          <source>VLC will be displayed in</source>
+          <target state="translated">VLC va fi afișat în</target>
+        </trans-unit>
+        <trans-unit id="ApplyAndRestart" translate="yes" xml:space="preserve">
+          <source>Apply And Restart</source>
+          <target state="translated">Aplică și repornește</target>
+        </trans-unit>
+        <trans-unit id="RefreshLanguage" translate="yes" xml:space="preserve">
+          <source>Refresh Language</source>
+          <target state="translated">Actualizați limba</target>
+        </trans-unit>
+        <trans-unit id="Local" translate="yes" xml:space="preserve">
+          <source>local</source>
+          <target state="translated">local</target>
+        </trans-unit>
+        <trans-unit id="WEBINTF_DOWNLOADFILES" translate="yes" xml:space="preserve">
+          <source>Download Files</source>
+          <target state="translated">Descărcare fișiere</target>
+        </trans-unit>
+        <trans-unit id="WEBINTF_DOWNLOADFILES_LONG" translate="yes" xml:space="preserve">
+          <source>Just click the file you want to download from your Xbox.</source>
+          <target state="translated">Faceți clic pe fișierul pe care doriți să îl descărcați de pe Xbox.</target>
+        </trans-unit>
+        <trans-unit id="WEBINTF_DROPFILES" translate="yes" xml:space="preserve">
+          <source>Drop Files</source>
+          <target state="translated">Trageți fișierele</target>
+        </trans-unit>
+        <trans-unit id="WEBINTF_DROPFILES_LONG" translate="yes" xml:space="preserve">
+          <source>Drop files in the window to add them to your Xbox.<it id="1" pos="open">&lt;br&gt;</it>Or click on the "+" button to use the file picker dialog.</source>
+          <target state="translated">Trageți fișierele în fereastră pentru a le adăuga la Xbox.<it id="1" pos="open">&lt;br&gt;</it>Sau click pe butonul "+" pentru a folosi fereastra de dialog de selectare a fișierelor..</target>
+        </trans-unit>
+        <trans-unit id="WEBINTF_TITLE" translate="yes" xml:space="preserve">
+          <source>Sharing via WiFi</source>
+          <target state="translated">Partajare prin WiFi</target>
+        </trans-unit>
+        <trans-unit id="CopyToLocalStorage" translate="yes" xml:space="preserve">
+          <source>copy to local storage</source>
+          <target state="translated">copiere în spațiul de stocare local</target>
+        </trans-unit>
+        <trans-unit id="ExternalStorageDeviceDetected" translate="yes" xml:space="preserve">
+          <source>VLC has detected an external storage device.</source>
+          <target state="translated">VLC a detectat un dispozitiv de stocare extern.</target>
+        </trans-unit>
+        <trans-unit id="ReadFromExternalStorage" translate="yes" xml:space="preserve">
+          <source>Use external storage as media library.</source>
+          <target state="translated">Utilizați spațiul de stocare extern ca bibliotecă media.</target>
+        </trans-unit>
+        <trans-unit id="SelectContentToCopy" translate="yes" xml:space="preserve">
+          <source>Copy media to the internal storage.</source>
+          <target state="translated">Copiați fișierele pe suportul intern de stocare.</target>
+        </trans-unit>
+        <trans-unit id="WhatToDo" translate="yes" xml:space="preserve">
+          <source>What would you like to do?</source>
+          <target state="translated">Ce ați dori să faceți?</target>
+        </trans-unit>
+        <trans-unit id="AskMe" translate="yes" xml:space="preserve">
+          <source>Ask me</source>
+          <target state="translated">Întreabă-mă</target>
+        </trans-unit>
+        <trans-unit id="ExternalStorage" translate="yes" xml:space="preserve">
+          <source>external storage</source>
+          <target state="translated">stocare externă</target>
+        </trans-unit>
+        <trans-unit id="WhatToDoWhenExternalStorage" translate="yes" xml:space="preserve">
+          <source>What should VLC do when an external storage device has been detected?</source>
+          <target state="translated">Ce ar trebui să facă VLC când detectează un dispozitiv de stocare extern?</target>
+        </trans-unit>
+        <trans-unit id="Cancel" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="translated">Anulare</target>
+        </trans-unit>
+        <trans-unit id="DoNothing" translate="yes" xml:space="preserve">
+          <source>Do nothing</source>
+          <target state="translated">Nimic</target>
+        </trans-unit>
+        <trans-unit id="Ok" translate="yes" xml:space="preserve">
+          <source>Ok</source>
+          <target state="translated">Ok</target>
+        </trans-unit>
+        <trans-unit id="Ignore" translate="yes" xml:space="preserve">
+          <source>Ignore</source>
+          <target state="translated">Ignorare</target>
+        </trans-unit>
+        <trans-unit id="Remember" translate="yes" xml:space="preserve">
+          <source>Remember</source>
+          <target state="translated">Ține minte</target>
+        </trans-unit>
+        <trans-unit id="AddMediaHelp" translate="yes" xml:space="preserve">
+          <source>Please insert an external storage device</source>
+          <target state="translated">Vă rugăm să introduceți un dispozitiv de stocare extern</target>
+        </trans-unit>
+        <trans-unit id="AddMediaHelpWithIP" translate="yes" xml:space="preserve">
+          <source>Please insert an external storage device, or go to http://{0}:8080 to upload some media</source>
+          <target state="translated">Vă rugăm să introduceți un dispozitiv de stocare extern sau să accesați http: // {0}: 8080 pentru a încărca unele materiale media</target>
+        </trans-unit>
+        <trans-unit id="CopyHelpDesktop" translate="yes" xml:space="preserve">
+          <source>Right-click on a file or a folder to copy it to the local storage.</source>
+          <target state="translated">Faceți clic dreapta pe un fișier sau pe un dosar pentru a-l copia în spațiul de stocare local.</target>
+        </trans-unit>
+        <trans-unit id="CopyHelpMediaCenter" translate="yes" xml:space="preserve">
+          <source>Press "Y" on a file or a folder to copy it to the local storage.</source>
+          <target state="translated">Apăsați "Y" pe un fișier sau pe un dosar pentru a-l copia în spațiul de stocare local.</target>
+        </trans-unit>
+        <trans-unit id="NoSubtitles" translate="yes" xml:space="preserve">
+          <source>No subtitle tracks</source>
+          <target state="translated">Nicio pistă de subtitrare</target>
+        </trans-unit>
+        <trans-unit id="ClearKeystore" translate="yes" xml:space="preserve">
+          <source>Clear saved credentials</source>
+          <target state="translated">Ștergeți acreditările salvate</target>
+        </trans-unit>
+        <trans-unit id="Credentials" translate="yes" xml:space="preserve">
+          <source>Credentials</source>
+          <target state="translated">Acreditări</target>
+        </trans-unit>
+        <trans-unit id="CopyHelpPhone" translate="yes" xml:space="preserve">
+          <source>Long press on a file or a folder to copy it to the local storage.</source>
+          <target state="translated">Apăsați lung un fișier sau un dosar pentru a-l copia în spațiul de stocare local.</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_FIT_SCREEN" translate="yes" xml:space="preserve">
+          <source>fit screen</source>
+          <target state="translated">potrivire ecran</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_FILL" translate="yes" xml:space="preserve">
+          <source>fill</source>
+          <target state="translated">complet</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_16_9" translate="yes" xml:space="preserve">
+          <source>16:9</source>
+          <target state="translated">16:9</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_4_3" translate="yes" xml:space="preserve">
+          <source>4:3</source>
+          <target state="translated">4:3</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_2_35_1" translate="yes" xml:space="preserve">
+          <source>2.35:1</source>
+          <target state="translated">2.35:1</target>
+        </trans-unit>
+        <trans-unit id="SURFACE_ORIGINAL" translate="yes" xml:space="preserve">
+          <source>original</source>
+          <target state="translated">original</target>
+        </trans-unit>
+        <trans-unit id="CompactOverlayPiP" translate="yes" xml:space="preserve">
+          <source>use windows 10 pip</source>
+          <target state="translated">utilizați windows 10 pip</target>
+        </trans-unit>
+        <trans-unit id="TvUnsafeArea" translate="yes" xml:space="preserve">
+          <source>TV unsafe area</source>
+          <target state="translated">zonă TV nesigură</target>
+        </trans-unit>
+        <trans-unit id="AddMarginExplanation" translate="yes" xml:space="preserve">
+          <source>Some TVs will not display the app correctly. To add some margin, turn this on</source>
+          <target state="translated">Unele televizoare nu vor afișa corect aplicația. Pentru a adăuga margini, activați această opțiune</target>
+        </trans-unit>
+        <trans-unit id="ExtraMargin" translate="yes" xml:space="preserve">
+          <source>Extra margin</source>
+          <target state="translated">Margini suplimentare</target>
+        </trans-unit>
+        <trans-unit id="NoExtraMargin" translate="yes" xml:space="preserve">
+          <source>No extra margin</source>
+          <target state="translated">Fără margini suplimentare</target>
+        </trans-unit>
+        <trans-unit id="Restart" translate="yes" xml:space="preserve">
+          <source>restart</source>
+          <target state="translated">repornire</target>
+        </trans-unit>
+        <trans-unit id="Disconnect" translate="yes" xml:space="preserve">
+          <source>disconnect</source>
+          <target state="translated">deconectare</target>
+        </trans-unit>
+        <trans-unit id="XboxUpload" translate="yes" xml:space="preserve">
+          <source>Xbox upload</source>
+          <target state="translated">încărcare Xbox</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/app/VLC.Universal/Strings/ko-KR/Resources.resw
+++ b/app/VLC.Universal/Strings/ko-KR/Resources.resw
@@ -310,7 +310,7 @@
     <value>재생목록</value>
   </data>
   <data name="PlaylistAlreadyExists" xml:space="preserve">
-    <value>이 아티스트는 이미 있습니다</value>
+    <value>이 아티스트는 이미 존재합니다</value>
   </data>
   <data name="PlaylistNamePlaceholder" xml:space="preserve">
     <value>재생목록 이름</value>
@@ -439,7 +439,7 @@
     <value>비디오</value>
   </data>
   <data name="VideoFolders" xml:space="preserve">
-    <value>비디오 ㅍ더</value>
+    <value>비디오 폴더</value>
   </data>
   <data name="VideoFoldersDescription" xml:space="preserve">
     <value>VLC는 비디오 라이브러리에 있는 비디오만 검색합니다. 여기 라이브러리에 폴더를 추가할 수 있습니다</value>
@@ -718,7 +718,7 @@
     <value>TV 영상에 불안전한 영역</value>
   </data>
   <data name="AddMarginExplanation" xml:space="preserve">
-    <value>일부 TV는 앱을 제대로 표시하지 못합니다. 여백을 약간 추가하려면, 이걸 켜세요</value>
+    <value>일부 TV는 앱을 정상적으로 표시하지 못합니다. 이 기능으로 약간의 여백을 추가할 수 있습니다.</value>
   </data>
   <data name="ExtraMargin" xml:space="preserve">
     <value>추가 여백</value>

--- a/app/VLC.Universal/Strings/pt-BR/Resources.resw
+++ b/app/VLC.Universal/Strings/pt-BR/Resources.resw
@@ -13,256 +13,256 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AboutTheApp" xml:space="preserve">
-    <value>Acerca de la app</value>
+    <value>Sobre o aplicativo</value>
   </data>
   <data name="Add" xml:space="preserve">
-    <value>Añadir</value>
+    <value>adicionar</value>
   </data>
   <data name="AddFolder" xml:space="preserve">
-    <value>añadir carpeta</value>
+    <value>adicionar pasta</value>
   </data>
   <data name="AddToCollection" xml:space="preserve">
-    <value>añadir a colección</value>
+    <value>adicionar à coleção</value>
   </data>
   <data name="AddToCurrentPlaylist" xml:space="preserve">
-    <value>añadir a lista de reproducción actual</value>
+    <value>adicionar à lista de reprodução atual</value>
   </data>
   <data name="AddToPlaylist" xml:space="preserve">
-    <value>añadir a lista de reproducción</value>
+    <value>Adicionar à lista de reprodução</value>
   </data>
   <data name="Albums" xml:space="preserve">
-    <value>álbumes</value>
+    <value>álbuns</value>
   </data>
   <data name="AlbumsFound" xml:space="preserve">
-    <value>álbumes encontrados : {0}</value>
+    <value>álbuns encontrados : {0}</value>
   </data>
   <data name="Animations" xml:space="preserve">
-    <value>animaciones</value>
+    <value>animações</value>
   </data>
   <data name="AppTheme" xml:space="preserve">
-    <value>tema de aplicación</value>
+    <value>tema do aplicativo</value>
   </data>
   <data name="Artists" xml:space="preserve">
     <value>artistas</value>
   </data>
   <data name="Audio" xml:space="preserve">
-    <value>audio</value>
+    <value>áudio</value>
   </data>
   <data name="AudioDelay" xml:space="preserve">
-    <value>retraso de audio</value>
+    <value>atraso do áudio</value>
   </data>
   <data name="AudioTracks" xml:space="preserve">
-    <value>Pistas de audio</value>
+    <value>Trilhas de Áudio</value>
   </data>
   <data name="Back" xml:space="preserve">
-    <value>atrás</value>
+    <value>voltar</value>
   </data>
   <data name="CameraRoll" xml:space="preserve">
-    <value>cámara</value>
+    <value>rolo de filme</value>
   </data>
   <data name="ChangeAlbumCover" xml:space="preserve">
-    <value>cambiar arte del álbum</value>
+    <value>mudar capa</value>
   </data>
   <data name="Chapters" xml:space="preserve">
     <value>Capítulos</value>
   </data>
   <data name="CheckCredentials" xml:space="preserve">
-    <value>ha ocurrido un error, consulte sus credenciales</value>
+    <value>Ocorreu um erro. Por favor verifique as suas credenciais</value>
   </data>
   <data name="Connect" xml:space="preserve">
     <value>conectar</value>
   </data>
   <data name="ConnectedToLastFM" xml:space="preserve">
-    <value>conectado a Last.FM</value>
+    <value>conectado ao Last.FM</value>
   </data>
   <data name="Connecting" xml:space="preserve">
     <value>conectando</value>
   </data>
   <data name="ConnectToLastFM" xml:space="preserve">
-    <value>conectado a Last.FM</value>
+    <value>conectar ao Last.FM</value>
   </data>
   <data name="CrashReport" xml:space="preserve">
-    <value>informe de error</value>
+    <value>relatório de falhas</value>
   </data>
   <data name="DecreaseSpeed" xml:space="preserve">
-    <value>decrementar velocidad</value>
+    <value>reduzir velocidade</value>
   </data>
   <data name="DecreaseVolume" xml:space="preserve">
-    <value>decrementar volumen</value>
+    <value>diminuir volume</value>
   </data>
   <data name="DeletePlaylist" xml:space="preserve">
-    <value>eliminar lista de reproducción</value>
+    <value>excluir lista de reprodução</value>
   </data>
   <data name="DeleteSelected" xml:space="preserve">
-    <value>eliminar seleccionado</value>
+    <value>excluir o item selecionado</value>
   </data>
   <data name="EditMetadata" xml:space="preserve">
-    <value>editar metadatos</value>
+    <value>editar metadados</value>
   </data>
   <data name="ElementsNotFound" xml:space="preserve">
-    <value>no se han encontrado elementos ahí</value>
+    <value>não foram encontrados elementos aqui</value>
   </data>
   <data name="EnterURL" xml:space="preserve">
-    <value>introduzca una url</value>
+    <value>digite a url</value>
   </data>
   <data name="Episode" xml:space="preserve">
-    <value>episodio</value>
+    <value>episódio</value>
   </data>
   <data name="EvenIfBackground" xml:space="preserve">
-    <value>incluso si la app está en segundo plano</value>
+    <value>mesmo se o aplicativo estiver em segundo plano</value>
   </data>
   <data name="EvenIfNotBackground" xml:space="preserve">
-    <value>incluso si la app no está en segundo plano</value>
+    <value>mesmo se o aplicativo não estiver em segundo plano</value>
   </data>
   <data name="FailFilePlayBackground" xml:space="preserve">
-    <value>Este archivo podría no reproducirse en segundo plano</value>
+    <value>Este arquivo não pode ser reproduzido em segundo plano</value>
   </data>
   <data name="FailNavigateVideoPlayerPage" xml:space="preserve">
-    <value>VLC falló al navegar a la página Video Player</value>
+    <value>O VLC não pôde navegar na página do Reprodutor de Vídeos</value>
   </data>
   <data name="FailOpenVideo" xml:space="preserve">
-    <value>VLC falló a abrir el vídeo</value>
+    <value>O VLC não pôde abrir o vídeo</value>
   </data>
   <data name="FailStartVLCEngine" xml:space="preserve">
-    <value>La app falló al iniciar el motor de VLC</value>
+    <value>O aplicativo falhou ao iniciar o mecanismo do VLC</value>
   </data>
   <data name="FeedbackThankYou" xml:space="preserve">
-    <value>¡retroalimentación enviada! gracias</value>
+    <value>sugestão enviada! Obrigado</value>
   </data>
   <data name="FileExplorer" xml:space="preserve">
-    <value>explorar</value>
+    <value>procurar</value>
   </data>
   <data name="HardwareDecoding" xml:space="preserve">
-    <value>decodificación por hardware</value>
+    <value>dispositivo de decodificação</value>
   </data>
   <data name="HardwareDecodingDescription" xml:space="preserve">
-    <value>La decodificación por hardware podría no funcionar en su dispositivo.</value>
+    <value>O dispositivo de decodificação pode não funcionar no seu aparelho.</value>
   </data>
   <data name="HaveToSelectPlaylist" xml:space="preserve">
-    <value>seleccione una lista de reproducción</value>
+    <value>por favor selecione uma lista de reprodução</value>
   </data>
   <data name="Home" xml:space="preserve">
-    <value>inicio</value>
+    <value>início</value>
   </data>
   <data name="HomePage" xml:space="preserve">
-    <value>página de inicio</value>
+    <value>página inicial</value>
   </data>
   <data name="HomePageDescription" xml:space="preserve">
-    <value>VLC iniciará en la página seleccionada</value>
+    <value>O VLC iniciará na página selecionada</value>
   </data>
   <data name="HoweverYouMayFindWhatYouWantHere" xml:space="preserve">
-    <value>sin embargo podrías encontrar lo que buscas aquí</value>
+    <value>entretanto você pode encontrar o que procura aqui</value>
   </data>
   <data name="HowToFavoriteAlbum1" xml:space="preserve">
-    <value>para preferir un álbum, simplemente presione</value>
+    <value>para tornar um álbum favorito, basta pressionar</value>
   </data>
   <data name="HowToFavoriteAlbum2" xml:space="preserve">
-    <value>y obtendrá acceso inmediato a él</value>
+    <value>e obterá um acesso instantâneo</value>
   </data>
   <data name="ImportantSponsors" xml:space="preserve">
-    <value>patrocinadores importantes</value>
+    <value>sensores importantes</value>
   </data>
   <data name="IncreaseSpeed" xml:space="preserve">
-    <value>incrementar velocidad</value>
+    <value>aumentar velocidade</value>
   </data>
   <data name="IncreaseVolume" xml:space="preserve">
-    <value>subir volumen</value>
+    <value>aumentar volume</value>
   </data>
   <data name="ItsEmpty" xml:space="preserve">
-    <value>está vacío</value>
+    <value>está vazio aqui</value>
   </data>
   <data name="KeyboardShortcuts" xml:space="preserve">
-    <value>teclas de acceso rápido</value>
+    <value>atalhos de teclado</value>
   </data>
   <data name="License" xml:space="preserve">
-    <value>licencia</value>
+    <value>licença</value>
   </data>
   <data name="Loading" xml:space="preserve">
-    <value>cargando</value>
+    <value>carregando</value>
   </data>
   <data name="LoadingMusic" xml:space="preserve">
-    <value>cargando música</value>
+    <value>carregando música</value>
   </data>
   <data name="MostPlayedArtists" xml:space="preserve">
-    <value>artistas más reproducidos</value>
+    <value>artistas mais reproduzidos</value>
   </data>
   <data name="Music" xml:space="preserve">
     <value>música</value>
   </data>
   <data name="MusicFolders" xml:space="preserve">
-    <value>carpetas de música</value>
+    <value>pastas de músicas</value>
   </data>
   <data name="MusicFoldersDescription" xml:space="preserve">
-    <value>VLC solo buscará canciones que estén en su librería de música. Puede añádir carpetas a su librería aquí</value>
+    <value>O VLC somente procurará músicas que estão na sua biblioteca de músicas. Adicione pastas à sua biblioteca aqui:</value>
   </data>
   <data name="MusicSettings" xml:space="preserve">
-    <value>Preferencias de música</value>
+    <value>Configurações de Músicas</value>
   </data>
   <data name="MusicShows" xml:space="preserve">
-    <value>programas de música</value>
+    <value>espetáculos musicais</value>
   </data>
   <data name="Mute" xml:space="preserve">
-    <value>silenciar</value>
+    <value>sem áudio</value>
   </data>
   <data name="MyPlaylists" xml:space="preserve">
-    <value>mis listas de reproducción</value>
+    <value>minhas listas de reprodução</value>
   </data>
   <data name="Network" xml:space="preserve">
-    <value>red</value>
+    <value>rede</value>
   </data>
   <data name="NewPlaylist" xml:space="preserve">
-    <value>nueva lista de reproducción</value>
+    <value>nova lista de reprodução</value>
   </data>
   <data name="NewVideos" xml:space="preserve">
-    <value>vídeos nuevos</value>
+    <value>novos vídeos</value>
   </data>
   <data name="No" xml:space="preserve">
-    <value>no</value>
+    <value>não</value>
   </data>
   <data name="NoBiographyFound" xml:space="preserve">
-    <value>no se ha encontrado bio para este artista</value>
+    <value>nenhuma biografia encontrada para este artista</value>
   </data>
   <data name="NoCameraVideosFound" xml:space="preserve">
-    <value>no se han encontrado vídeos de cámara</value>
+    <value>nenhuma câmera de vídeo encontrada</value>
   </data>
   <data name="NoFavoriteAlbums" xml:space="preserve">
-    <value>no hay álbumes preferidos</value>
+    <value>nenhum álbum favorito</value>
   </data>
   <data name="NoInternetConnection" xml:space="preserve">
-    <value>no hay conexión a internet</value>
+    <value>sem conexão com a Internet</value>
   </data>
   <data name="NoPlaylists" xml:space="preserve">
-    <value>no hay listas de reprodicción</value>
+    <value>sem listas de reprodução</value>
   </data>
   <data name="NoShowsFound" xml:space="preserve">
-    <value>no se han econtrado programas</value>
+    <value>nenhum espetáculo encontrado</value>
   </data>
   <data name="NothingToSeeHere" xml:space="preserve">
-    <value>no hay nada que ver aquí</value>
+    <value>Nada para ver aqui</value>
   </data>
   <data name="Notifications" xml:space="preserve">
-    <value>notificaciones</value>
+    <value>notificações</value>
   </data>
   <data name="NotificationWhenSongStarts" xml:space="preserve">
-    <value>cuando la canción empieza</value>
+    <value>quando a música inicia</value>
   </data>
   <data name="NoVideosFound" xml:space="preserve">
-    <value>no se ha encontrado vídeo</value>
+    <value>Não foram encontrados vídeos</value>
   </data>
   <data name="NowPlaying" xml:space="preserve">
-    <value>reproduciendo ahora</value>
+    <value>reproduzindo</value>
   </data>
   <data name="OpenFile" xml:space="preserve">
-    <value>abrir archivo</value>
+    <value>abrir arquivo</value>
   </data>
   <data name="OpenStream" xml:space="preserve">
-    <value>abrir emision</value>
+    <value>abrir fluxo de rede</value>
   </data>
   <data name="OpenSubtitle" xml:space="preserve">
-    <value>abrir subtítulos</value>
+    <value>abrir legenda</value>
   </data>
   <data name="OrderAscending" xml:space="preserve">
-    <value>ascendentemente</value>
+    <value>ascendente</value>
   </data>
   <data name="OrderByAlbum" xml:space="preserve">
     <value>por álbum</value>
@@ -271,217 +271,217 @@
     <value>por artista</value>
   </data>
   <data name="OrderByDate" xml:space="preserve">
-    <value>por fecha</value>
+    <value>por data</value>
   </data>
   <data name="OrderDescending" xml:space="preserve">
-    <value>descendentemente</value>
+    <value>descendente</value>
   </data>
   <data name="Password" xml:space="preserve">
-    <value>contraseña</value>
+    <value>senha</value>
   </data>
   <data name="Pause" xml:space="preserve">
     <value>pausar</value>
   </data>
   <data name="PinAlbum" xml:space="preserve">
-    <value>fijar álbum</value>
+    <value>pinar álbum</value>
   </data>
   <data name="PinArtist" xml:space="preserve">
-    <value>fijar artista</value>
+    <value>pinar artista</value>
   </data>
   <data name="Play" xml:space="preserve">
-    <value>reproducir</value>
+    <value>reproduzir</value>
   </data>
   <data name="PlayAlbum" xml:space="preserve">
-    <value>reproducir álbum</value>
+    <value>reproduzir o álbum</value>
   </data>
   <data name="PlayAll" xml:space="preserve">
-    <value>reproducir todo</value>
+    <value>Reproduzir tudo</value>
   </data>
   <data name="Playback" xml:space="preserve">
-    <value>reproducción</value>
+    <value>reprodução</value>
   </data>
   <data name="PlayerSettings" xml:space="preserve">
-    <value>Preferencias del reproductor</value>
+    <value>Configurações do Reprodutor</value>
   </data>
   <data name="PlayFolder" xml:space="preserve">
-    <value>reproducir carpeta</value>
+    <value>reproduzir pasta</value>
   </data>
   <data name="Playlist" xml:space="preserve">
-    <value>lista de reproducción</value>
+    <value>lista de reprodução</value>
   </data>
   <data name="PlaylistAlreadyExists" xml:space="preserve">
-    <value>la lista de reproducción ya existe</value>
+    <value>esta lista de reprodução já existe</value>
   </data>
   <data name="PlaylistNamePlaceholder" xml:space="preserve">
-    <value>nombre de lista de reproducción</value>
+    <value>nome da lista de reprodução</value>
   </data>
   <data name="Playlists" xml:space="preserve">
-    <value>listas de reproducción</value>
+    <value>listas de reprodução</value>
   </data>
   <data name="PlayTrack" xml:space="preserve">
-    <value>reproducir pista</value>
+    <value>reproduzir trilha</value>
   </data>
   <data name="PlayVideo" xml:space="preserve">
-    <value>reproducir vídeo</value>
+    <value>reproduzir vídeo</value>
   </data>
   <data name="PrivacyStatement" xml:space="preserve">
-    <value>declaración de privacidad</value>
+    <value>declaração de privacidade</value>
   </data>
   <data name="Favorites" xml:space="preserve">
     <value>Favoritos</value>
   </data>
   <data name="RefreshMusicLibrary" xml:space="preserve">
-    <value>refrescar la librería de música</value>
+    <value>atualizar biblioteca de músicas</value>
   </data>
   <data name="RefreshVideoLibrary" xml:space="preserve">
-    <value>refrescar la librería de vídeo</value>
+    <value>atualizar biblioteca de vídeos</value>
   </data>
   <data name="RemovableStorage" xml:space="preserve">
-    <value>almacenamiento extraíble</value>
+    <value>armazenamento removível</value>
   </data>
   <data name="RemoveFolder" xml:space="preserve">
-    <value>eliminar carpeta</value>
+    <value>excluir pasta</value>
   </data>
   <data name="RemoveMusicFolderDescription" xml:space="preserve">
-    <value>Si no quiere esta carpeta en su librería de músca puede eiminarla. Afectará a todas las apps, no solo a VLC</value>
+    <value>Se não desejar esta pasta em sua Biblioteca de Músicas, é possível removê-la. Afetará todos os aplicativos, não somente o VLC</value>
   </data>
   <data name="RemoveVideoFolderDescription" xml:space="preserve">
-    <value>Si no quiere esta carpeta en su librería de vídeo puede eiminarla. Afectará a todas las apps, no solo a VLC</value>
+    <value>Se não desejar esta pasta em sua Biblioteca de Vídeos, é possível removê-la. Afetará todos os aplicativos, não somente o VLC</value>
   </data>
   <data name="Reset" xml:space="preserve">
     <value>restaurar</value>
   </data>
   <data name="ResetMusicDatabase" xml:space="preserve">
-    <value>restaurar base de datos de música</value>
+    <value>reiniciar o banco de dados de músicas</value>
   </data>
   <data name="ResetSpeed" xml:space="preserve">
-    <value>restaurar velocidad</value>
+    <value>restaurar velocidade</value>
   </data>
   <data name="RichAnimationsDescription" xml:space="preserve">
-    <value>Usar animaciones ricas en presentaciones</value>
+    <value>Usar animações ricas em apresentações</value>
   </data>
   <data name="Search" xml:space="preserve">
-    <value>buscar</value>
+    <value>procurar</value>
   </data>
   <data name="Season" xml:space="preserve">
     <value>temporada</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>preferencias</value>
+    <value>configurações</value>
   </data>
   <data name="ShowPlaylist" xml:space="preserve">
-    <value>mostrar lista de reproducción</value>
+    <value>exibir lista de reprodução</value>
   </data>
   <data name="Shows" xml:space="preserve">
-    <value>programas</value>
+    <value>apresentações</value>
   </data>
   <data name="Shuffle" xml:space="preserve">
-    <value>aleatorio</value>
+    <value>aleatório</value>
   </data>
   <data name="Songs" xml:space="preserve">
-    <value>canciones</value>
+    <value>músicas</value>
   </data>
   <data name="SpecialThanks" xml:space="preserve">
-    <value>agradecimientos especiales</value>
+    <value>agradecimento especial</value>
   </data>
   <data name="Speed" xml:space="preserve">
-    <value>velocidad</value>
+    <value>velocidade</value>
   </data>
   <data name="Stop" xml:space="preserve">
     <value>parar</value>
   </data>
   <data name="SubtitleDelay" xml:space="preserve">
-    <value>retraso de subtítulos</value>
+    <value>atraso de legenda</value>
   </data>
   <data name="Subtitles" xml:space="preserve">
-    <value>subtítulos</value>
+    <value>Legendas</value>
   </data>
   <data name="SubtitlesEncoding" xml:space="preserve">
-    <value>codificación de subtítulos</value>
+    <value>codificação de legendas</value>
   </data>
   <data name="Theme" xml:space="preserve">
     <value>tema</value>
   </data>
   <data name="TileRemoved" xml:space="preserve">
-    <value>baldosa eliminada</value>
+    <value>mosaico removido</value>
   </data>
   <data name="TopVideos" xml:space="preserve">
-    <value>vídeos populares</value>
+    <value>vídeos mais vistos</value>
   </data>
   <data name="TrackAddedToYourPlaylist" xml:space="preserve">
-    <value>pista añadida a la lista de reproducción</value>
+    <value>trilha adicionada à lista de reprodução</value>
   </data>
   <data name="TrackAlreadyExistsInPlaylist" xml:space="preserve">
-    <value>esta pista ya está añadida en la lista de reproducción</value>
+    <value>esta trilha já está na lista de reprodução</value>
   </data>
   <data name="Tracks" xml:space="preserve">
-    <value>pistas</value>
+    <value>trilhas</value>
   </data>
   <data name="UnknownAlbum" xml:space="preserve">
-    <value>Álbum desconocido</value>
+    <value>álbum desconhecido</value>
   </data>
   <data name="UnknownArtist" xml:space="preserve">
-    <value>artista desconocido</value>
+    <value>artista desconhecido</value>
   </data>
   <data name="UnknownShow" xml:space="preserve">
-    <value>programa desconocido</value>
+    <value>Espetáculo desconhecido</value>
   </data>
   <data name="UnknownTrack" xml:space="preserve">
-    <value>pista desconocida</value>
+    <value>Trilha desconhecida</value>
   </data>
   <data name="UserInterface" xml:space="preserve">
-    <value>interfaz de usuario</value>
+    <value>Interface de Usuário</value>
   </data>
   <data name="Username" xml:space="preserve">
-    <value>nombre de usuario</value>
+    <value>nome de usuário</value>
   </data>
   <data name="Video" xml:space="preserve">
     <value>vídeo</value>
   </data>
   <data name="VideoFolders" xml:space="preserve">
-    <value>carpetas de vídeo</value>
+    <value>pastas de vídeos</value>
   </data>
   <data name="VideoFoldersDescription" xml:space="preserve">
-    <value>VLC solo buscará vídeos que estén en su librería de vídeo. Puede añádir carpetas a su librería aquí</value>
+    <value>O VLC somente procurará vídeos que estão na sua biblioteca de vídeos. Adicione pastas à sua biblioteca aqui</value>
   </data>
   <data name="VideoPlayback" xml:space="preserve">
-    <value>reproducción de vídeo</value>
+    <value>reprodução de vídeo</value>
   </data>
   <data name="VideoPlaybackInBackground" xml:space="preserve">
-    <value>reproducir vídeo en segundo plano</value>
+    <value>reproduzir vídeo em segundo plano</value>
   </data>
   <data name="Videos" xml:space="preserve">
     <value>vídeos</value>
   </data>
   <data name="VideoSettings" xml:space="preserve">
-    <value>Preferencias de vídeo</value>
+    <value>Configurações de Vídeo</value>
   </data>
   <data name="ViewAlbum" xml:space="preserve">
-    <value>ver álbum</value>
+    <value>Exibir álbum</value>
   </data>
   <data name="ViewArtist" xml:space="preserve">
-    <value>ver artista</value>
+    <value>exibir artista</value>
   </data>
   <data name="Volume" xml:space="preserve">
-    <value>volumen</value>
+    <value>volume</value>
   </data>
   <data name="WeNeedYourHelp" xml:space="preserve">
-    <value>necesitamos su ayuda</value>
+    <value>Precisamos da sua ajuda</value>
   </data>
   <data name="Yes" xml:space="preserve">
-    <value>sí</value>
+    <value>sim</value>
   </data>
   <data name="YourMusic" xml:space="preserve">
-    <value>tu música</value>
+    <value>sua música</value>
   </data>
   <data name="AccentColor" xml:space="preserve">
-    <value>acentuar color</value>
+    <value>cor do realce</value>
   </data>
   <data name="BackgroundColor" xml:space="preserve">
-    <value>color de fondo</value>
+    <value>cor de fundo</value>
   </data>
   <data name="Dark" xml:space="preserve">
-    <value>oscuro</value>
+    <value>escuro</value>
   </data>
   <data name="Light" xml:space="preserve">
     <value>claro</value>
@@ -490,22 +490,22 @@
     <value>barra de título</value>
   </data>
   <data name="NeedRestart" xml:space="preserve">
-    <value>Necesita reiniciar la app para aplicar los cambios</value>
+    <value>É necessário reiniciar o aplicativo para aplicar as modificações</value>
   </data>
   <data name="Zoom" xml:space="preserve">
-    <value>ampliar</value>
+    <value>aproximação</value>
   </data>
   <data name="AreYouSure" xml:space="preserve">
-    <value>¿Está seguro?</value>
+    <value>tem certeza?</value>
   </data>
   <data name="MediaCantBeRead" xml:space="preserve">
-    <value>el medio no puede ser leído</value>
+    <value>a mídia não pode ser lida</value>
   </data>
   <data name="Sorry" xml:space="preserve">
-    <value>lo sentimos</value>
+    <value>pedimos desculpas</value>
   </data>
   <data name="SURFACE_BEST_FIT" xml:space="preserve">
-    <value>mejor ajuste</value>
+    <value>melhor enquadramento</value>
   </data>
   <data name="SURFACE_FIT_HORIZONTAL" xml:space="preserve">
     <value>recorte horizontal</value>
@@ -514,46 +514,46 @@
     <value>recorte vertical</value>
   </data>
   <data name="YourPlaylistWontBeAccessible" xml:space="preserve">
-    <value>su lista de reproducción no será accesible</value>
+    <value>sua lista de reprodução não é acessível</value>
   </data>
   <data name="NoArtistShowsFound" xml:space="preserve">
-    <value>no se han encontrado programas para este artista</value>
+    <value>Não foram encontrados espetáculos desse artista</value>
   </data>
   <data name="NoResults" xml:space="preserve">
-    <value>no hay resultados</value>
+    <value>sem resultados</value>
   </data>
   <data name="ForceLandscape" xml:space="preserve">
-    <value>forzar apaisado</value>
+    <value>Impor paisagem</value>
   </data>
   <data name="SURFACE_STRETCH" xml:space="preserve">
-    <value>estirar</value>
+    <value>ajustar</value>
   </data>
   <data name="SimilarArtists" xml:space="preserve">
     <value>Artistas similares</value>
   </data>
   <data name="EnglishLanguage" xml:space="preserve">
-    <value>Inglés</value>
+    <value>Inglês</value>
   </data>
   <data name="FrenchLanguage" xml:space="preserve">
-    <value>Francés</value>
+    <value>Francês</value>
   </data>
   <data name="JapaneseLanguage" xml:space="preserve">
-    <value>Japonés</value>
+    <value>Japonês</value>
   </data>
   <data name="GermanLanguage" xml:space="preserve">
-    <value>Alemán</value>
+    <value>Alemão</value>
   </data>
   <data name="PolishLanguage" xml:space="preserve">
-    <value>Polaco</value>
+    <value>Polonês</value>
   </data>
   <data name="SlovakLanguage" xml:space="preserve">
     <value>Eslovaco</value>
   </data>
   <data name="DanishLanguage" xml:space="preserve">
-    <value>Danés</value>
+    <value>Dinamarquês</value>
   </data>
   <data name="SpanishLanguage" xml:space="preserve">
-    <value>Español</value>
+    <value>Espanhol</value>
   </data>
   <data name="HungarianLanguage" xml:space="preserve">
     <value>Húngaro</value>
@@ -565,16 +565,16 @@
     <value>Coreano</value>
   </data>
   <data name="MalayLanguage" xml:space="preserve">
-    <value>Malayo</value>
+    <value>Malaio</value>
   </data>
   <data name="NorwegianLanguage" xml:space="preserve">
-    <value>Noruego</value>
+    <value>Norueguês</value>
   </data>
   <data name="DutchLanguage" xml:space="preserve">
-    <value>Holandés</value>
+    <value>Holandês</value>
   </data>
   <data name="RussianLanguage" xml:space="preserve">
-    <value>Ruso</value>
+    <value>Russo</value>
   </data>
   <data name="SwedishLanguage" xml:space="preserve">
     <value>Sueco</value>
@@ -586,118 +586,118 @@
     <value>Ucraniano</value>
   </data>
   <data name="ChineseLanguage" xml:space="preserve">
-    <value>Chino</value>
+    <value>Chinês</value>
   </data>
   <data name="PortugueseLanguage" xml:space="preserve">
-    <value>Portugués</value>
+    <value>Português</value>
   </data>
   <data name="CzechLanguage" xml:space="preserve">
-    <value>Checo</value>
+    <value>Tcheco</value>
   </data>
   <data name="IcelandicLanguage" xml:space="preserve">
-    <value>Islandés</value>
+    <value>Islandês</value>
   </data>
   <data name="HebrewLanguage" xml:space="preserve">
-    <value>Hebreo</value>
+    <value>Hebraico</value>
   </data>
   <data name="Languages" xml:space="preserve">
     <value>Idiomas</value>
   </data>
   <data name="SelectLanguageDescription" xml:space="preserve">
-    <value>VLC se mostrará en</value>
+    <value>O VLC será exibido em</value>
   </data>
   <data name="ApplyAndRestart" xml:space="preserve">
-    <value>Aplicar y reiniciar</value>
+    <value>Aplicar e Reiniciar</value>
   </data>
   <data name="RefreshLanguage" xml:space="preserve">
-    <value>Actualizar idioma</value>
+    <value>Atualizar Idiomas</value>
   </data>
   <data name="Local" xml:space="preserve">
     <value>local</value>
   </data>
   <data name="WEBINTF_DOWNLOADFILES" xml:space="preserve">
-    <value>Descargar archivos</value>
+    <value>Baixar Arquivos</value>
   </data>
   <data name="WEBINTF_DOWNLOADFILES_LONG" xml:space="preserve">
-    <value>Haga clic en el archivo que quiere descargar de su Xbox.</value>
+    <value>Clique no arquivo que deseja baixar do seu Xbox.</value>
   </data>
   <data name="WEBINTF_DROPFILES" xml:space="preserve">
-    <value>Dejar caer archivos</value>
+    <value>Soltar Arquivos</value>
   </data>
   <data name="WEBINTF_DROPFILES_LONG" xml:space="preserve">
-    <value>Deje caer archivos en la ventana para añadirlos a su Xbox.&lt;br&gt;O haga clic en el botón «+» para usar el diálogo de selección de archivos.</value>
+    <value>Solte arquivos na janela para adicioná-los ao seu Xbox.&lt;br&gt;Ou clique no botão "+" para usar a janela de escolha de arquivos.</value>
   </data>
   <data name="WEBINTF_TITLE" xml:space="preserve">
-    <value>Compartir mediante WiFi</value>
+    <value>Compartilhando via WiFi</value>
   </data>
   <data name="CopyToLocalStorage" xml:space="preserve">
-    <value>copiar a almacenamiento local</value>
+    <value>copiar para um armazenamento local</value>
   </data>
   <data name="ExternalStorageDeviceDetected" xml:space="preserve">
-    <value>VLC ha detectado un dispositivo de almacenamiento externo.</value>
+    <value>O VLC detectou um dispositivo de armazenamento externo.</value>
   </data>
   <data name="ReadFromExternalStorage" xml:space="preserve">
-    <value>Usar almacenamiento externo como librería de medios.</value>
+    <value>Usa o armazenamento externo como biblioteca de mídias.</value>
   </data>
   <data name="SelectContentToCopy" xml:space="preserve">
-    <value>Copiar el medio al almacenamiento interno.</value>
+    <value>Copia a mídia para o armazenamento interno.</value>
   </data>
   <data name="WhatToDo" xml:space="preserve">
-    <value>¿Que desea hacer?</value>
+    <value>O que gostaria de fazer?</value>
   </data>
   <data name="AskMe" xml:space="preserve">
-    <value>Preguntar</value>
+    <value>Perguntar</value>
   </data>
   <data name="ExternalStorage" xml:space="preserve">
-    <value>almacenamiento externo</value>
+    <value>armazenamento externo</value>
   </data>
   <data name="WhatToDoWhenExternalStorage" xml:space="preserve">
-    <value>¿Que debería hacer VLC cuando se detecta un dispositivo de almacenamiento externo?</value>
+    <value>O que o VLC deverá fazer quando um armazenamento externo for detectado?</value>
   </data>
   <data name="Cancel" xml:space="preserve">
     <value>Cancelar</value>
   </data>
   <data name="DoNothing" xml:space="preserve">
-    <value>No hacer nada</value>
+    <value>Não fazer nada</value>
   </data>
   <data name="Ok" xml:space="preserve">
-    <value>Aceptar</value>
+    <value>Ok</value>
   </data>
   <data name="Ignore" xml:space="preserve">
     <value>Ignorar</value>
   </data>
   <data name="Remember" xml:space="preserve">
-    <value>Recordar</value>
+    <value>Salvar</value>
   </data>
   <data name="AddMediaHelp" xml:space="preserve">
-    <value>Inserte un dispositivo de almacenamiento externo</value>
+    <value>Por favor insira um dispositivo de armazenamento externo</value>
   </data>
   <data name="AddMediaHelpWithIP" xml:space="preserve">
-    <value>Inserte un dispositivo de almacenamiento externo o vaya a http://{0}:8080 para subir algún medio</value>
+    <value>Por favor insira um dispositivo de armazenamento externo ou acesse http://{0}:8080 para enviar mídia</value>
   </data>
   <data name="CopyHelpDesktop" xml:space="preserve">
-    <value>Clic-derecho en un archio o carpeta para copiar al almacenamiento local.</value>
+    <value>Clique com o botão direito em um arquivo ou pasta para copiá-lo para um armazenamento local.</value>
   </data>
   <data name="CopyHelpMediaCenter" xml:space="preserve">
-    <value>Presione «Y» en un archivo o carpeta para copiar al almacenamiento local.</value>
+    <value>Pressione "Y" em um arquivo ou pasta para copiá-lo para um armazenamento local.</value>
   </data>
   <data name="NoSubtitles" xml:space="preserve">
-    <value>No hay pistas de subtítulos</value>
+    <value>Sem trilhas de legenda</value>
   </data>
   <data name="ClearKeystore" xml:space="preserve">
-    <value>Limpiar credenciales guardadas</value>
+    <value>Limpar credenciais salvas</value>
   </data>
   <data name="Credentials" xml:space="preserve">
-    <value>Credenciales</value>
+    <value>Credenciais</value>
   </data>
   <data name="CopyHelpPhone" xml:space="preserve">
-    <value>Presión larga en un archivo o carpeta para copiar al almacenamiento local.</value>
+    <value>Pressione e segure em um arquivo ou pasta para copiá-lo para um armazenamento local.</value>
   </data>
   <data name="SURFACE_FIT_SCREEN" xml:space="preserve">
-    <value>ajustar a pantalla</value>
+    <value>ajustar à tela</value>
   </data>
   <data name="SURFACE_FILL" xml:space="preserve">
-    <value>rellenar</value>
+    <value>preencher</value>
   </data>
   <data name="SURFACE_16_9" xml:space="preserve">
     <value>16:9</value>
@@ -706,33 +706,33 @@
     <value>4:3</value>
   </data>
   <data name="SURFACE_2_35_1" xml:space="preserve">
-    <value>2.35:1</value>
+    <value>2,35:1</value>
   </data>
   <data name="SURFACE_ORIGINAL" xml:space="preserve">
     <value>original</value>
   </data>
   <data name="CompactOverlayPiP" xml:space="preserve">
-    <value>usar pip de windows 10</value>
+    <value>usar o pip do windows 10</value>
   </data>
   <data name="TvUnsafeArea" xml:space="preserve">
-    <value>Area insegura de TV</value>
+    <value>Área de TV insegura</value>
   </data>
   <data name="AddMarginExplanation" xml:space="preserve">
-    <value>Algunas TVs no mostrarán la app correctamente. Para añadir algo de margen, active esto</value>
+    <value>Algumas TV não exibirão o aplicativo corretamente. Para adicionar uma margem, habilite esta função</value>
   </data>
   <data name="ExtraMargin" xml:space="preserve">
-    <value>Margen extra</value>
+    <value>Margem extra</value>
   </data>
   <data name="NoExtraMargin" xml:space="preserve">
-    <value>Sin margen extra</value>
+    <value>Sem margem extra</value>
   </data>
   <data name="Restart" xml:space="preserve">
     <value>reiniciar</value>
   </data>
   <data name="Disconnect" xml:space="preserve">
-    <value>desconectar</value>
+    <value>disconectar</value>
   </data>
   <data name="XboxUpload" xml:space="preserve">
-    <value>Subida Xbox</value>
+    <value>Envio ao Xbox</value>
   </data>
 </root>

--- a/app/VLC.Universal/Strings/pt-PT/Resources.resw
+++ b/app/VLC.Universal/Strings/pt-PT/Resources.resw
@@ -151,7 +151,7 @@
     <value>O VLC irá iniciar na página selecionada</value>
   </data>
   <data name="HoweverYouMayFindWhatYouWantHere" xml:space="preserve">
-    <value>contudo você pode encontrar o que procura aqui</value>
+    <value>contudo pode encontrar o que procura aqui</value>
   </data>
   <data name="HowToFavoriteAlbum1" xml:space="preserve">
     <value>para favoritar um álbum, apenas pressione</value>
@@ -199,7 +199,7 @@
     <value>Definições de Música</value>
   </data>
   <data name="MusicShows" xml:space="preserve">
-    <value>Shows de música</value>
+    <value>Programas de música</value>
   </data>
   <data name="Mute" xml:space="preserve">
     <value>silenciar</value>
@@ -223,7 +223,7 @@
     <value>nenhuma biografia encontrada para este artista</value>
   </data>
   <data name="NoCameraVideosFound" xml:space="preserve">
-    <value>não foram encontrados vídeos de câmera</value>
+    <value>não foram encontrados vídeos de câmara</value>
   </data>
   <data name="NoFavoriteAlbums" xml:space="preserve">
     <value>sem álbuns favoritos</value>
@@ -436,7 +436,7 @@
     <value>nome de utilizador</value>
   </data>
   <data name="Video" xml:space="preserve">
-    <value>video</value>
+    <value>vídeo</value>
   </data>
   <data name="VideoFolders" xml:space="preserve">
     <value>pastas de vídeo</value>
@@ -718,7 +718,7 @@
     <value>àrea não segura para TV</value>
   </data>
   <data name="AddMarginExplanation" xml:space="preserve">
-    <value>Algumas TVs não mostrarão a app correctamente. Para adicionar alguma margem, active isto</value>
+    <value>Algumas TVs não mostrarão a app corretamente. Para adicionar alguma margem, ative isto</value>
   </data>
   <data name="ExtraMargin" xml:space="preserve">
     <value>Margem extra</value>

--- a/app/VLC.Universal/VLC.Universal.csproj
+++ b/app/VLC.Universal/VLC.Universal.csproj
@@ -361,6 +361,7 @@
     <None Include="VLC_WinRT.Universal_TemporaryKey.pfx" />
     <PRIResource Include="Strings\cs-CZ\Resources.resw" />
     <PRIResource Include="Strings\pt-PT\Resources.resw" />
+    <PRIResource Include="Strings\pt-BR\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\libvlc\Universal\vlc-$(TargetedSDKArchitecture)\$(Configuration)\libvlc.dll">
@@ -1666,6 +1667,7 @@
     <XliffResource Include="MultilingualResources\VLC.Universal.nb-NO.xlf" />
     <XliffResource Include="MultilingualResources\VLC.Universal.nl-NL.xlf" />
     <XliffResource Include="MultilingualResources\VLC.Universal.pl-PL.xlf" />
+    <XliffResource Include="MultilingualResources\VLC.Universal.pt-BR.xlf" />
     <XliffResource Include="MultilingualResources\VLC.Universal.pt-PT.xlf" />
     <XliffResource Include="MultilingualResources\VLC.Universal.ru-RU.xlf" />
     <XliffResource Include="MultilingualResources\VLC.Universal.sk-SK.xlf" />


### PR DESCRIPTION
Some translations made after the last update. This are only the xlf files, generating to resw will be needed.

@mfkl the new PT Brazilian language isn't activated yet because the proper name for the string is missing.